### PR TITLE
fix #310, limit Boolean value

### DIFF
--- a/src/ffmpeg/types.py
+++ b/src/ffmpeg/types.py
@@ -6,7 +6,9 @@ The source of these types is defined within the AVOptionType enumeration found i
 
 from typing import Literal
 
-Boolean = bool | Literal["true", "false", "1", "0"]
+from .schema import Default
+
+Boolean = bool | Literal["true", "false", "1", "0"] | Default
 """
 This represents FFmpeg's boolean type. It can accept either a Python boolean value (`True` or `False`)
 or a string that represents a boolean value ("true", "false", "1", or "0").

--- a/src/ffmpeg/types.py
+++ b/src/ffmpeg/types.py
@@ -4,7 +4,9 @@ These option types can be one of several different categories.
 The source of these types is defined within the AVOptionType enumeration found in FFmpeg's opt.h header file.
 """
 
-Boolean = bool | str
+from typing import Literal
+
+Boolean = bool | Literal["true", "false", "1", "0"]
 """
 This represents FFmpeg's boolean type. It can accept either a Python boolean value (`True` or `False`)
 or a string that represents a boolean value ("true", "false", "1", or "0").


### PR DESCRIPTION
- fix #310 limit Boolean's Typing to only accept `0`, `1`, `true`, `false`

IDE support

![Screenshot 2024-02-22 at 8 21 08 AM](https://github.com/livingbio/typed-ffmpeg/assets/432851/63b2aab2-a458-4ea3-9b68-cc269586d039)