### PR TITLE
hofix #317 remove not necessary map

### DIFF
--- a/src/ffmpeg/dag/nodes.py
+++ b/src/ffmpeg/dag/nodes.py
@@ -170,7 +170,11 @@ class FilterableStream(Stream):
             the output stream
         """
         return self.filter_multi_output(
-            *streams, name=name, input_typings=input_typings, output_typings=(StreamType.video,), **kwargs
+            *streams,
+            name=name,
+            input_typings=input_typings,
+            output_typings=(StreamType.video,),
+            **kwargs,
         ).video(0)
 
     def afilter(
@@ -193,7 +197,11 @@ class FilterableStream(Stream):
             the output stream
         """
         return self.filter_multi_output(
-            *streams, name=name, input_typings=input_typings, output_typings=(StreamType.audio,), **kwargs
+            *streams,
+            name=name,
+            input_typings=input_typings,
+            output_typings=(StreamType.audio,),
+            **kwargs,
         ).audio(0)
 
     def filter_multi_output(
@@ -404,11 +412,16 @@ class OutputNode(Node):
     def get_args(self, context: DAGContext = None) -> list[str]:
         # !handle mapping
         commands = []
-        for input in self.inputs:
-            if isinstance(input.node, InputNode):
-                commands += ["-map", input.label(context)]
-            else:
-                commands += ["-map", f"[{input.label(context)}]"]
+
+        if context and (
+            any(isinstance(k.node, FilterNode) for k in self.inputs)
+            or len([k for k in context.all_nodes if isinstance(k, OutputNode)]) > 1
+        ):
+            for input in self.inputs:
+                if isinstance(input.node, InputNode):
+                    commands += ["-map", input.label(context)]
+                else:
+                    commands += ["-map", f"[{input.label(context)}]"]
 
         for key, value in self.kwargs:
             if isinstance(value, bool) and value is True:
@@ -458,7 +471,10 @@ class OutputStream(Stream):
         return GlobalNode(inputs=(self,), kwargs=(("y", True),)).stream()
 
     def compile(
-        self, cmd: str | list[str] = "ffmpeg", overwrite_output: bool = False, auto_fix: bool = True
+        self,
+        cmd: str | list[str] = "ffmpeg",
+        overwrite_output: bool = False,
+        auto_fix: bool = True,
     ) -> list[str]:
         """
         Build command-line for invoking ffmpeg.
@@ -482,7 +498,10 @@ class OutputStream(Stream):
         return cmd + compile(self, auto_fix=auto_fix)
 
     def compile_line(
-        self, cmd: str | list[str] = "ffmpeg", overwrite_output: bool = False, auto_fix: bool = True
+        self,
+        cmd: str | list[str] = "ffmpeg",
+        overwrite_output: bool = False,
+        auto_fix: bool = True,
     ) -> str:
         """
         Build command-line for invoking ffmpeg.

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_assemble_video_from_sequence_of_frames.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_assemble_video_from_sequence_of_frames.json
@@ -6,7 +6,5 @@
   "glob",
   "-i",
   "/path/to/jpegs/*.jpg",
-  "-map",
-  "0",
   "movie.mp4"
 ]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_concat_dumuxer.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_concat_dumuxer.json
@@ -7,8 +7,6 @@
   "-protocol_whitelist",
   "file,http,https,tcp,tls",
   "-i",
-  "input1.mp4",
-  "-map",
-  "0",
+  "files.txt",
   "output.mp4"
 ]

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -144,7 +144,7 @@ def test_compile_merge_outputs_with_filter_complex(snapshot: SnapshotAssertion) 
 
 def test_concat_dumuxer(snapshot: SnapshotAssertion) -> None:
     stream = input(
-        "input1.mp4",
+        "files.txt",
         f="concat",
         safe="0",
         protocol_whitelist="file,http,https,tcp,tls",


### PR DESCRIPTION
Hotfix for Issue #317: 
Removed unnecessary map to align behavior with ffmpeg-python standards. Now, if there's no complex filter and only a single output file, the map will not be used.