### PR TITLE
fix #401 module name conflict

### DIFF
--- a/.github/workflows/python-publish-compatible.yml
+++ b/.github/workflows/python-publish-compatible.yml
@@ -44,5 +44,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-      - run: poetry install --with dev
-      - run: poetry run mkdocs gh-deploy --force

--- a/.github/workflows/python-publish-compatible.yml
+++ b/.github/workflows/python-publish-compatible.yml
@@ -1,0 +1,48 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install Poetry & export Requirements
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry self add poetry-dynamic-versioning[plugin]
+      - name: build compatible version
+        run: |
+          mv pyproject-compatible.toml pyproject.toml
+          mv src/ffmpeg src/typed_ffmpeg
+      - name: Build package
+        run: poetry build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - run: poetry install --with dev
+      - run: poetry run mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pip install typed-ffmpeg
 
 Note: FFmpeg must be installed on your system.
 
+Note: If you need to install `ffmpeg-python` at the same time, use `pip install typed-ffmpeg-compatible` to prevent conflicts with the module name.​
+
 ### Visualization Support
 
 To enable graph visualization features:

--- a/pyproject-compatible.toml
+++ b/pyproject-compatible.toml
@@ -1,0 +1,102 @@
+[tool.poetry]
+name = "typed-ffmpeg-compatible"
+version = "0.0.0"
+description = "Modern Python FFmpeg wrappers offer comprehensive support for complex filters, complete with detailed typing and documentation."
+authors = ["lucemia <lucemia@gmail.com>"]
+readme = "README.md"
+packages = [{ include = "typed_ffmpeg", from = "src" }]
+include = ["typed_ffmpeg/py.typed"]
+exclude = ["**/tests", "**/scripts"]
+license = "MIT"
+homepage = "https://livingbio.github.io/typed-ffmpeg/"
+repository = "https://github.com/livingbio/typed-ffmpeg"
+keywords = [
+    "ffmpeg",
+    "video",
+    "audio",
+    "multimedia",
+    "filter",
+]
+classifiers = [
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Topic :: Multimedia :: Video',
+        'Topic :: Multimedia :: Sound/Audio',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Application Frameworks',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+
+# graph
+graphviz = {"version" = "*", optional=true}
+
+[tool.poetry.extras]
+graph = [
+    "graphviz",
+]
+
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+# test
+pytest-cov = ">=4.1,<6.0"
+pytest-datadir = "^1.5.0"
+pytest-recording = "^0.13.1"
+syrupy = "^4.6.0"
+pre-commit = "*"
+mypy = "*"
+graphviz = "*"
+
+# codegen
+typer = "*"
+jinja2 = "*"
+devtools = "*"
+beautifulsoup4 = "*"
+html2text = "*"
+
+# Doc
+mkdocs = "*"
+markdown-callouts = "^0.4.0"
+mkdocs-material = "^9.5.9"
+mkdocstrings = ">=0.24,<0.27"
+mkdocstrings-python = "^1.8.0"
+pymdown-extensions = "^10.7"
+griffe_inherited_docstrings = "*"
+black = "*"
+ipykernel = "^6.29.4"
+mknotebooks = "*"
+
+[tool.mypy]
+exclude = "^(migrations|commands|sandbox|samples|sdk)/"
+show_error_codes = true       # Enables showing error codes in messages for easier issue identification.
+implicit_optional = true      # Assumes arguments with a default `None` value are `Optional`.
+follow_imports = "silent"     # Ignores import errors for a cleaner output on external libraries.
+warn_redundant_casts = true   # Issues warnings for unnecessary type casts.
+warn_unused_ignores = true    # Alerts on unnecessary '# type: ignore' comments.
+disallow_any_generics = true  # Forces specifying types for generics, like `List[int]` instead of just `List`.
+check_untyped_defs = true     # Would type-check functions without type annotations, but it's commented out.
+no_implicit_reexport = true   # Requires explicit re-export of imported names.
+disallow_untyped_defs = true  # Forces all functions to have type annotations.
+
+[tool.poetry.scripts]
+scripts = "scripts.main:app"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+pattern = "default-unprefixed"
+
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"

--- a/src/ffmpeg/base.py
+++ b/src/ffmpeg/base.py
@@ -4,11 +4,10 @@ This module defined the basic functions for creating the ffmpeg filter graph.
 
 from typing import Any
 
-from ffmpeg.schema import StreamType
-
 from .dag.io._input import input
 from .dag.io._output import output
 from .dag.nodes import FilterableStream, FilterNode, GlobalNode, GlobalStream, OutputStream
+from .schema import StreamType
 from .streams.audio import AudioStream
 from .streams.video import VideoStream
 

--- a/src/ffmpeg/dag/validate.py
+++ b/src/ffmpeg/dag/validate.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from ffmpeg.exceptions import FFMpegValueError
-
+from ..exceptions import FFMpegValueError
 from ..streams.audio import AudioStream
 from ..streams.video import VideoStream
 from .context import DAGContext

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -2,10 +2,9 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
-from ffmpeg.schema import StreamType
-
 from ..base import input, merge_outputs, output, vfilter
 from ..filters import concat, join
+from ..schema import StreamType
 from ..streams.video import VideoStream
 
 


### PR DESCRIPTION
- fix #401 
- add a mirror package to avoid module name conflict with `ffmpeg-python`
- use relative import to avoid issue while change the module name

`pip install typed-ffmpeg-compatible`