### PR TITLE
Fixed incorrect string escaping.

### DIFF
--- a/src/ffmpeg/streams/video.py
+++ b/src/ffmpeg/streams/video.py
@@ -7909,7 +7909,7 @@ class VideoStream(FilterableStream):
         Args:
             datapath: set datapath
             language: set language (default "eng")
-            whitelist: set character whitelist (default "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.:;,-+_!?"'[]{}()|/\=*&%$#@!~ ")
+            whitelist: set character whitelist (default "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.:;,-+_!?"'[]{}()|/\\=*&%$#@!~ ")
             blacklist: set character blacklist (default "")
 
         Returns:


### PR DESCRIPTION
Prior to this I was seeing warnings on Python 3.12:
```
>>> import ffmpeg
/Users/austin/repos/typed-ffmpeg/src/ffmpeg/streams/video.py:7905: SyntaxWarning: invalid escape sequence '\='
```