### PR TITLE
fix #441 change filter_node_factory's parameter's name to avoid conflict

### DIFF
--- a/src/ffmpeg/dag/factory.py
+++ b/src/ffmpeg/dag/factory.py
@@ -8,7 +8,7 @@ from .nodes import FilterableStream, FilterNode
 
 
 def filter_node_factory(
-    filter: FFMpegFilterDef, *inputs: FilterableStream, **kwargs: Any
+    ffmpeg_filter_def: FFMpegFilterDef, *inputs: FilterableStream, **kwargs: Any
 ) -> FilterNode:
     for k, v in kwargs.items():
         if isinstance(v, Auto):
@@ -16,28 +16,34 @@ def filter_node_factory(
                 v, {"StreamType": StreamType, "re": re, **kwargs, "streams": inputs}
             )
 
-    if isinstance(filter.typings_input, str):
+    if isinstance(ffmpeg_filter_def.typings_input, str):
         input_typings = tuple(
-            eval(filter.typings_input, {"StreamType": StreamType, "re": re, **kwargs})
+            eval(
+                ffmpeg_filter_def.typings_input,
+                {"StreamType": StreamType, "re": re, **kwargs},
+            )
         )
     else:
         input_typings = tuple(
             StreamType.video if k == "video" else StreamType.audio
-            for k in filter.typings_input
+            for k in ffmpeg_filter_def.typings_input
         )
 
-    if isinstance(filter.typings_output, str):
+    if isinstance(ffmpeg_filter_def.typings_output, str):
         output_typings = tuple(
-            eval(filter.typings_output, {"StreamType": StreamType, "re": re, **kwargs})
+            eval(
+                ffmpeg_filter_def.typings_output,
+                {"StreamType": StreamType, "re": re, **kwargs},
+            )
         )
     else:
         output_typings = tuple(
             StreamType.video if k == "video" else StreamType.audio
-            for k in filter.typings_output
+            for k in ffmpeg_filter_def.typings_output
         )
 
     return FilterNode(
-        name=filter.name,
+        name=ffmpeg_filter_def.name,
         input_typings=input_typings,
         output_typings=output_typings,
         inputs=inputs,

--- a/src/ffmpeg/streams/tests/__snapshots__/test_audio.ambr
+++ b/src/ffmpeg/streams/tests/__snapshots__/test_audio.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_showwavespic
+  "ffmpeg -i test-input.mp4 -filter_complex '[0:a]showwavespic[s0]' -map '[s0]' -f image2 -vframes 1 -vcodec mjpeg pipe:"
+# ---

--- a/src/ffmpeg/streams/tests/test_audio.py
+++ b/src/ffmpeg/streams/tests/test_audio.py
@@ -1,0 +1,12 @@
+from syrupy.assertion import SnapshotAssertion
+
+import ffmpeg
+
+
+def test_showwavespic(snapshot: SnapshotAssertion) -> None:
+    assert snapshot == (
+        ffmpeg.input("test-input.mp4")
+        .audio.showwavespic()
+        .output(filename="pipe:", vframes=1, f="image2", vcodec="mjpeg")
+        .compile_line()
+    )


### PR DESCRIPTION
fix #441 change filter_node_factory's parameter's name to avoid conflict with `filter`