### PR TITLE
more docstrings

### DIFF
--- a/src/ffmpeg/common/schema.py
+++ b/src/ffmpeg/common/schema.py
@@ -1,3 +1,11 @@
+"""
+Schema definitions for FFmpeg filters and options.
+
+This module defines the core data structures and enumerations used to represent
+FFmpeg filters, their options, and stream types. These schemas are used throughout
+the typed-ffmpeg library to provide type-safe interfaces to FFmpeg functionality.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -7,16 +15,30 @@ from typing import Literal
 
 class StreamType(str, Enum):
     """
-    The type of a stream. (audio or video)
+    Enumeration of possible stream types in FFmpeg.
+
+    This enum defines the fundamental types of media streams that can be
+    processed by FFmpeg filters. Each stream in FFmpeg is either an audio
+    stream or a video stream, and filters are designed to work with
+    specific stream types.
     """
 
     audio = "audio"
-    """it is an audio stream"""
+    """Represents an audio stream containing sound data"""
+
     video = "video"
-    """it is a video stream"""
+    """Represents a video stream containing visual frame data"""
 
 
 class FFMpegFilterOptionType(str, Enum):
+    """
+    Enumeration of possible data types for FFmpeg filter options.
+
+    This enum defines the various data types that can be used for options
+    in FFmpeg filters. Each type corresponds to a specific kind of value
+    that can be passed to a filter parameter.
+    """
+
     boolean = "boolean"
     duration = "duration"
     color = "color"
@@ -36,86 +58,232 @@ class FFMpegFilterOptionType(str, Enum):
 
 
 class FFMpegFilterType(str, Enum):
+    """
+    Enumeration of FFmpeg filter types based on input/output stream types.
+
+    This enum categorizes filters according to what types of streams they
+    process and produce. The naming convention follows FFmpeg's internal
+    categorization of filters.
+    """
+
     af = "af"
+    """Audio filter: processes audio and outputs audio"""
+
     asrc = "asrc"
+    """Audio source: generates audio without input"""
+
     asink = "asink"
+    """Audio sink: consumes audio without producing output"""
+
     vf = "vf"
+    """Video filter: processes video and outputs video"""
+
     vsrc = "vsrc"
+    """Video source: generates video without input"""
+
     vsink = "vsink"
+    """Video sink: consumes video without producing output"""
+
     avsrc = "avsrc"
+    """Audio-video source: generates both audio and video without input"""
+
     avf = "avf"
+    """Audio-video filter: processes and outputs both audio and video"""
+
     vaf = "vaf"
+    """Video-to-audio filter: processes video and outputs audio"""
 
 
 @dataclass(frozen=True, kw_only=True)
 class FFMpegFilterOptionChoice:
+    """
+    Represents a single choice for an FFmpeg filter option with enumerated values.
+
+    Some FFmpeg filter options accept only specific enumerated values. This class
+    represents one such value along with its description and internal representation.
+    """
+
     name: str
+    """The name of the choice as it appears in FFmpeg documentation"""
+
     help: str
+    """Description of what this choice does"""
+
     value: str | int
+    """The actual value to pass to FFmpeg when this choice is selected"""
+
     flags: str | None = None
+    """Optional flags associated with this choice"""
 
 
 @dataclass(frozen=True, kw_only=True)
 class FFMpegFilterOption:
+    """
+    Represents a configurable option for an FFmpeg filter.
+
+    This class defines the metadata for a single option that can be passed to
+    an FFmpeg filter, including its type, constraints, and default value.
+    """
+
     name: str
+    """The primary name of the option as used in FFmpeg"""
+
     alias: tuple[str, ...] = ()
+    """Alternative names that can be used for this option"""
+
     description: str
+    """Human-readable description of what the option does"""
+
     type: FFMpegFilterOptionType
+    """The data type of the option (boolean, int, string, etc.)"""
+
     min: str | None = None
+    """Minimum allowed value for numeric options"""
+
     max: str | None = None
+    """Maximum allowed value for numeric options"""
+
     default: bool | int | float | str | None = None
+    """Default value used by FFmpeg if the option is not specified"""
+
     required: bool = False
+    """Whether the option must be provided or can be omitted"""
+
     choices: tuple[FFMpegFilterOptionChoice, ...] = ()
+    """Enumerated values that this option accepts, if applicable"""
+
     flags: str | None = None
+    """Optional flags that modify the behavior of this option"""
 
 
 @dataclass(frozen=True, kw_only=True)
 class FFMpegIOType:
+    """
+    Defines the type information for a filter's input or output stream.
+
+    This class associates a name with a stream type (audio or video) for
+    a specific input or output of an FFmpeg filter.
+    """
+
     name: str | None = None
+    """Optional name for this input/output stream"""
+
     type: StreamType
+    """The type of the stream (audio or video)"""
 
 
 @dataclass(frozen=True, kw_only=True)
 class FFMpegFilterDef:
+    """
+    Defines the basic structure of an FFmpeg filter.
+
+    This class provides a simplified representation of an FFmpeg filter,
+    focusing on its name and the types of its inputs and outputs.
+    """
+
     name: str
+    """The name of the filter as used in FFmpeg"""
 
     typings_input: str | tuple[Literal["video", "audio"], ...] = ()
+    """
+    The types of input streams this filter accepts.
+    Can be a tuple of stream types or a string expression that evaluates to a tuple.
+    """
+
     typings_output: str | tuple[Literal["video", "audio"], ...] = ()
+    """
+    The types of output streams this filter produces.
+    Can be a tuple of stream types or a string expression that evaluates to a tuple.
+    """
 
 
 @dataclass(frozen=True, kw_only=True)
 class FFMpegFilter:
+    """
+    Comprehensive representation of an FFmpeg filter with all its metadata.
+
+    This class contains the complete definition of an FFmpeg filter, including
+    its name, description, capabilities, input/output specifications, and options.
+    It serves as the central schema for representing filters in typed-ffmpeg.
+    """
+
     id: str | None = None
+    """Optional unique identifier for the filter"""
 
     name: str
+    """The name of the filter as used in FFmpeg commands"""
+
     description: str
+    """Human-readable description of what the filter does"""
+
     ref: str | None = None
+    """Optional reference to documentation or source code"""
 
     # Flags
     is_support_slice_threading: bool | None = None
+    """Whether the filter supports slice-based multithreading"""
+
     is_support_timeline: bool | None = None
+    """Whether the filter supports timeline editing features"""
+
     is_support_framesync: bool | None = None
+    """Whether the filter supports frame synchronization"""
+
     is_support_command: bool | None = None
+    """Whether the filter supports runtime commands"""
+
     is_filter_sink: bool | None = None
+    """Whether the filter is a sink (consumes input without producing output)"""
+
     is_filter_source: bool | None = None
+    """Whether the filter is a source (produces output without requiring input)"""
 
     # IO Typing
     is_dynamic_input: bool = False
+    """Whether the filter can accept a variable number of inputs"""
+
     is_dynamic_output: bool = False
+    """Whether the filter can produce a variable number of outputs"""
+
     stream_typings_input: tuple[FFMpegIOType, ...] = ()
+    """The types of input streams this filter accepts"""
+
     stream_typings_output: tuple[FFMpegIOType, ...] = ()
+    """The types of output streams this filter produces"""
+
     formula_typings_input: str | None = None
+    """Optional formula to dynamically determine input types"""
+
     formula_typings_output: str | None = None
+    """Optional formula to dynamically determine output types"""
 
     pre: tuple[tuple[str, str], ...] = ()
+    """Pre-defined parameter pairs for the filter"""
+
     options: tuple[FFMpegFilterOption, ...] = ()
+    """The configurable options this filter accepts"""
 
     @property
     def pre_dict(self) -> dict[str, str]:
+        """
+        Convert the pre-defined parameter pairs to a dictionary.
+
+        Returns:
+            A dictionary mapping parameter names to their values
+        """
         return dict(self.pre)
 
     @property
     def to_def(self) -> FFMpegFilterDef:
+        """
+        Convert this comprehensive filter definition to a simplified FFMpegFilterDef.
+
+        This creates a simplified representation of the filter focusing only on
+        its name and input/output types, which is useful for filter node creation.
+
+        Returns:
+            A simplified FFMpegFilterDef representation of this filter
+        """
         return FFMpegFilterDef(
             name=self.name,
             typings_input=self.formula_typings_input
@@ -126,6 +294,18 @@ class FFMpegFilter:
 
     @property
     def input_typings(self) -> set[StreamType]:
+        """
+        Determine the set of input stream types this filter accepts.
+
+        This property analyzes the filter's input specifications to determine
+        what types of streams (audio, video, or both) it can accept as input.
+
+        Returns:
+            A set of StreamType values representing accepted input types
+
+        Raises:
+            AssertionError: If a dynamic input filter has no input formula
+        """
         if self.is_filter_source:
             return set()
         if not self.is_dynamic_input:
@@ -150,6 +330,18 @@ class FFMpegFilter:
 
     @property
     def output_typings(self) -> set[StreamType]:
+        """
+        Determine the set of output stream types this filter produces.
+
+        This property analyzes the filter's output specifications to determine
+        what types of streams (audio, video, or both) it can produce as output.
+
+        Returns:
+            A set of StreamType values representing produced output types
+
+        Raises:
+            AssertionError: If a dynamic output filter has no output formula
+        """
         if self.is_filter_sink:
             return set()
         if not self.is_dynamic_output:
@@ -174,6 +366,22 @@ class FFMpegFilter:
 
     @property
     def filter_type(self) -> FFMpegFilterType:
+        """
+        Determine the FFmpeg filter type based on input and output stream types.
+
+        This property analyzes the filter's input and output specifications to
+        determine which category of filter it belongs to according to FFmpeg's
+        classification system (audio filter, video filter, source, sink, etc.).
+
+        Returns:
+            The appropriate FFMpegFilterType for this filter
+
+        Raises:
+            ValueError: If the filter's input/output configuration doesn't match
+                       any known filter type
+            AssertionError: If a sink filter has multiple input types or
+                           if a filter has no input types
+        """
         if self.is_filter_sink:
             assert len(self.input_typings) == 1
             if {StreamType.video} == self.input_typings:
@@ -284,35 +492,96 @@ class FFMpegOptionFlag(int, Enum):
 
 
 class FFMpegOptionType(str, Enum):
+    """
+    Enumeration of FFmpeg option data types.
+
+    This enum defines the various data types that can be used for FFmpeg
+    command-line options. These types correspond to the internal option
+    types defined in FFmpeg's libavutil/opt.h header.
+    """
+
     OPT_TYPE_FUNC = "OPT_TYPE_FUNC"
+    """Function option type, typically used for callback functions"""
+
     OPT_TYPE_BOOL = "OPT_TYPE_BOOL"
+    """Boolean option type (true/false)"""
+
     OPT_TYPE_STRING = "OPT_TYPE_STRING"
+    """String option type"""
+
     OPT_TYPE_INT = "OPT_TYPE_INT"
+    """Integer option type"""
+
     OPT_TYPE_INT64 = "OPT_TYPE_INT64"
+    """64-bit integer option type"""
+
     OPT_TYPE_FLOAT = "OPT_TYPE_FLOAT"
+    """Floating-point option type"""
+
     OPT_TYPE_DOUBLE = "OPT_TYPE_DOUBLE"
+    """Double-precision floating-point option type"""
+
     OPT_TYPE_TIME = "OPT_TYPE_TIME"
+    """Time value option type (e.g., duration in seconds)"""
 
 
 @dataclass(frozen=True, kw_only=True)
 class FFMpegOption:
+    """
+    Represents a command-line option for FFmpeg.
+
+    This class defines the metadata for a single option that can be passed
+    to the FFmpeg command line, including its type, help text, and flags
+    that determine its behavior.
+    """
+
     name: str
+    """The name of the option as used in FFmpeg commands"""
+
     type: FFMpegOptionType
+    """The data type of the option (boolean, int, string, etc.)"""
+
     flags: int
+    """Bitmap of FFMpegOptionFlag values that define the option's behavior"""
+
     help: str
+    """Human-readable description of what the option does"""
+
     argname: str | None = None
+    """Optional name for the option's argument in help text"""
+
     canon: str | None = None
+    """For alternative option forms, the name of the canonical option"""
 
     @property
     def is_input_option(self) -> bool:
+        """
+        Check if this option applies to input files.
+
+        Returns:
+            True if this option is meant to be used with input files
+        """
         return bool(self.flags & FFMpegOptionFlag.OPT_INPUT)
 
     @property
     def is_output_option(self) -> bool:
+        """
+        Check if this option applies to output files.
+
+        Returns:
+            True if this option is meant to be used with output files
+        """
         return bool(self.flags & FFMpegOptionFlag.OPT_OUTPUT)
 
     @property
     def is_global_option(self) -> bool:
+        """
+        Check if this option applies globally rather than to specific files.
+
+        Returns:
+            True if this option is a global option that doesn't apply to
+            specific input or output files
+        """
         return (
             not self.is_input_option
             and not self.is_output_option
@@ -321,4 +590,13 @@ class FFMpegOption:
 
     @property
     def is_support_stream_specifier(self) -> bool:
+        """
+        Check if this option supports stream specifiers.
+
+        Stream specifiers allow options to be applied to specific streams
+        within a file, using syntax like "-c:v" for video codec.
+
+        Returns:
+            True if this option can be used with stream specifiers
+        """
         return bool(self.flags & FFMpegOptionFlag.OPT_SPEC)

--- a/src/ffmpeg/dag/__init__.py
+++ b/src/ffmpeg/dag/__init__.py
@@ -1,3 +1,16 @@
+"""
+Directed Acyclic Graph (DAG) implementation for FFmpeg filter chains.
+
+This package provides the core components for representing FFmpeg filter chains
+as directed acyclic graphs. It includes classes for different types of nodes
+(inputs, filters, outputs) and streams, as well as utilities for validating,
+compiling, and manipulating these graphs.
+
+The DAG structure enables type-safe construction and validation of complex
+FFmpeg filter chains, ensuring that the resulting FFmpeg commands are valid
+and correctly structured.
+"""
+
 from .nodes import (
     FilterableStream,
     FilterNode,

--- a/src/ffmpeg/dag/factory.py
+++ b/src/ffmpeg/dag/factory.py
@@ -1,3 +1,11 @@
+"""
+Factory functions for creating FFmpeg filter nodes.
+
+This module provides factory functions that create filter nodes based on
+FFmpeg filter definitions. These factories handle the evaluation of automatic
+parameters and the conversion of input/output typing specifications.
+"""
+
 import re
 from typing import Any
 
@@ -10,6 +18,25 @@ from .nodes import FilterableStream, FilterNode
 def filter_node_factory(
     ffmpeg_filter_def: FFMpegFilterDef, *inputs: FilterableStream, **kwargs: Any
 ) -> FilterNode:
+    """
+    Create a FilterNode from an FFmpeg filter definition.
+
+    This function creates a FilterNode based on the provided FFmpeg filter definition.
+    It handles the evaluation of Auto parameters and the conversion of input/output
+    typing specifications from the filter definition.
+
+    Args:
+        ffmpeg_filter_def: The FFmpeg filter definition to create a node from
+        *inputs: The input streams to connect to the filter
+        **kwargs: Filter-specific parameters as keyword arguments
+
+    Returns:
+        A FilterNode configured according to the filter definition
+
+    Note:
+        This function is primarily used internally by the filter generation system
+        to create filter nodes from the FFmpeg filter definitions.
+    """
     for k, v in kwargs.items():
         if isinstance(v, Auto):
             kwargs[k] = eval(

--- a/src/ffmpeg/dag/global_runnable/runnable.py
+++ b/src/ffmpeg/dag/global_runnable/runnable.py
@@ -1,3 +1,12 @@
+"""
+Execution capabilities for FFmpeg filter graphs.
+
+This module provides the GlobalRunable class, which extends GlobalArgs with
+methods for executing FFmpeg commands. It enables compiling filter graphs
+into command-line arguments and running FFmpeg processes both synchronously
+and asynchronously.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -15,24 +24,57 @@ logger = logging.getLogger(__name__)
 
 
 class GlobalRunable(GlobalArgs):
+    """
+    Base class that provides execution capabilities for FFmpeg filter graphs.
+
+    This class extends GlobalArgs with methods for compiling filter graphs into
+    FFmpeg command-line arguments and executing FFmpeg processes. It serves as
+    a mixin for stream classes that need to be executed as FFmpeg commands.
+    """
+
     def merge_outputs(self, *streams: OutputStream) -> GlobalStream:
         """
-        Merge multiple output streams into one.
+        Merge multiple output streams into a single command.
+
+        This method allows combining multiple output files into a single FFmpeg
+        command, which is more efficient than running separate commands for each
+        output. It creates a GlobalNode that includes all the specified output
+        streams.
 
         Args:
-            *streams: The output streams to merge.
+            *streams: Additional output streams to include in the same command
 
         Returns:
-            The merged output stream.
+            A GlobalStream that represents the combined outputs
+
+        Example:
+            ```python
+            # Create two output files with one command
+            video = ffmpeg.input("input.mp4").video
+            output1 = video.output("output1.mp4")
+            output2 = video.output("output2.webm")
+            merged = output1.merge_outputs(output2)
+            merged.run()  # Creates both output files with one FFmpeg command
+            ```
         """
         return self._global_node(*streams).stream()
 
     def overwrite_output(self) -> GlobalStream:
         """
-        Overwrite output files without asking (ffmpeg `-y` option)
+        Set the FFmpeg command to overwrite output files without asking.
+
+        This method adds the `-y` option to the FFmpeg command, which causes
+        FFmpeg to overwrite output files without prompting for confirmation.
+        It's equivalent to calling `global_args(y=True)`.
 
         Returns:
-            the output stream
+            A GlobalStream with the overwrite option enabled
+
+        Example:
+            ```python
+            # Overwrite output file if it already exists
+            ffmpeg.input("input.mp4").output("output.mp4").overwrite_output().run()
+            ```
         """
         return self._global_node(y=True).stream()
 
@@ -43,15 +85,31 @@ class GlobalRunable(GlobalArgs):
         auto_fix: bool = True,
     ) -> list[str]:
         """
-        Build command-line for invoking ffmpeg.
+        Build command-line arguments for invoking FFmpeg.
+
+        This method converts the filter graph into a list of command-line
+        arguments that can be passed to subprocess functions or executed
+        directly. It handles the FFmpeg executable name, overwrite options,
+        and automatic fixing of the filter graph.
 
         Args:
-            cmd: the command to invoke ffmpeg
-            overwrite_output: whether to overwrite output files without asking
-            auto_fix: whether to automatically fix the stream
+            cmd: The FFmpeg executable name or path, or a list containing
+                 the executable and initial arguments
+            overwrite_output: If True, add the -y option to overwrite output files
+                             If False, add the -n option to never overwrite
+                             If None (default), use the current settings
+            auto_fix: Whether to automatically fix issues in the filter graph,
+                     such as adding split filters for reused streams
 
         Returns:
-            the command-line
+            A list of strings representing the complete FFmpeg command
+
+        Example:
+            ```python
+            # Get the command-line arguments for a filter graph
+            args = ffmpeg.input("input.mp4").output("output.mp4").compile()
+            # Result: ['ffmpeg', '-i', 'input.mp4', 'output.mp4']
+            ```
         """
         from ..compile import compile
 
@@ -72,15 +130,29 @@ class GlobalRunable(GlobalArgs):
         auto_fix: bool = True,
     ) -> str:
         """
-        Build command-line for invoking ffmpeg.
+        Build a command-line string for invoking FFmpeg.
+
+        This method is similar to compile(), but returns a single string with
+        proper escaping instead of a list of arguments. This is useful for
+        logging or displaying the command to users.
 
         Args:
-            cmd: the command to invoke ffmpeg
-            overwrite_output: whether to overwrite output files without asking
-            auto_fix: whether to automatically fix the stream
+            cmd: The FFmpeg executable name or path, or a list containing
+                 the executable and initial arguments
+            overwrite_output: If True, add the -y option to overwrite output files
+                             If False, add the -n option to never overwrite
+                             If None (default), use the current settings
+            auto_fix: Whether to automatically fix issues in the filter graph
 
         Returns:
-            the command-line
+            A string representing the complete FFmpeg command with proper escaping
+
+        Example:
+            ```python
+            # Get a command-line string for a filter graph
+            cmd_str = ffmpeg.input("input.mp4").output("output.mp4").compile_line()
+            # Result: 'ffmpeg -i input.mp4 output.mp4'
+            ```
         """
         return command_line(
             self.compile(cmd, overwrite_output=overwrite_output, auto_fix=auto_fix)
@@ -97,19 +169,34 @@ class GlobalRunable(GlobalArgs):
         auto_fix: bool = True,
     ) -> subprocess.Popen[bytes]:
         """
-        Run ffmpeg asynchronously.
+        Run FFmpeg asynchronously as a subprocess.
+
+        This method executes the FFmpeg command in a separate process without
+        waiting for it to complete. This is useful for long-running operations
+        or when you need to interact with the process while it's running.
 
         Args:
-            cmd: the command to invoke ffmpeg
-            pipe_stdin: whether to pipe stdin
-            pipe_stdout: whether to pipe stdout
-            pipe_stderr: whether to pipe stderr
-            quiet: whether to pipe stderr to stdout
-            overwrite_output: whether to overwrite output files without asking
-            auto_fix: whether to automatically fix the stream
+            cmd: The FFmpeg executable name or path, or a list containing
+                 the executable and initial arguments
+            pipe_stdin: Whether to create a pipe for writing to the process's stdin
+            pipe_stdout: Whether to create a pipe for reading from the process's stdout
+            pipe_stderr: Whether to create a pipe for reading from the process's stderr
+            quiet: Whether to capture stderr (implies pipe_stderr=True)
+            overwrite_output: If True, add the -y option to overwrite output files
+                             If False, add the -n option to never overwrite
+                             If None (default), use the current settings
+            auto_fix: Whether to automatically fix issues in the filter graph
 
         Returns:
-            the process
+            A subprocess.Popen object representing the running FFmpeg process
+
+        Example:
+            ```python
+            # Start FFmpeg process and interact with it
+            process = ffmpeg.input("input.mp4").output("output.mp4").run_async()
+            # Do something while FFmpeg is running
+            process.wait()  # Wait for completion
+            ```
         """
 
         args = self.compile(cmd, overwrite_output=overwrite_output, auto_fix=auto_fix)
@@ -139,20 +226,42 @@ class GlobalRunable(GlobalArgs):
         auto_fix: bool = True,
     ) -> tuple[bytes, bytes]:
         """
-        Run ffmpeg synchronously.
+        Run FFmpeg synchronously and wait for completion.
+
+        This method executes the FFmpeg command in a separate process and waits
+        for it to complete before returning. It's the most common way to run
+        FFmpeg commands when you just want to process media files.
 
         Args:
-            cmd: the command to invoke ffmpeg
-            capture_stdout: whether to capture stdout
-            capture_stderr: whether to capture stderr
-            input: the input
-            quiet: whether to pipe stderr to stdout
-            overwrite_output: whether to overwrite output files without asking
-            auto_fix: whether to automatically fix the stream
+            cmd: The FFmpeg executable name or path, or a list containing
+                 the executable and initial arguments
+            capture_stdout: Whether to capture and return the process's stdout
+            capture_stderr: Whether to capture and return the process's stderr
+            input: Optional bytes to write to the process's stdin
+            quiet: Whether to suppress output to the console
+            overwrite_output: If True, add the -y option to overwrite output files
+                             If False, add the -n option to never overwrite
+                             If None (default), use the current settings
+            auto_fix: Whether to automatically fix issues in the filter graph
 
         Returns:
-            stdout: he stdout
-            stderr: the stderr
+            A tuple of (stdout_bytes, stderr_bytes), which will be empty bytes
+            objects if the respective capture_* parameter is False
+
+        Raises:
+            FFMpegExecuteError: If the FFmpeg process returns a non-zero exit code
+
+        Example:
+            ```python
+            # Process a video file
+            stdout, stderr = ffmpeg.input("input.mp4").output("output.mp4").run()
+
+            # Capture FFmpeg's output
+            stdout, stderr = (
+                ffmpeg.input("input.mp4").output("output.mp4").run(capture_stderr=True)
+            )
+            print(stderr.decode())  # Print FFmpeg's progress information
+            ```
         """
 
         process = self.run_async(

--- a/src/ffmpeg/dag/nodes.py
+++ b/src/ffmpeg/dag/nodes.py
@@ -174,7 +174,8 @@ class FilterNode(Node):
 
         This method creates the filter string that will be used in the
         filter_complex argument of the FFmpeg command. The format follows
-        FFmpeg's syntax: [in1][in2]filtername=param1=value1:param2=value2[out]
+        FFmpeg's syntax where input labels are followed by the filter name
+        and parameters, and then output labels.
 
         Args:
             context: Optional DAG context for resolving stream labels.

--- a/src/ffmpeg/dag/utils.py
+++ b/src/ffmpeg/dag/utils.py
@@ -1,22 +1,43 @@
+"""
+Utility functions for working with directed acyclic graphs (DAGs).
+
+This module provides functions for validating and analyzing graph structures,
+particularly for ensuring that filter graphs are properly formed as DAGs
+without cycles, which is a requirement for FFmpeg filter chains.
+"""
+
 from __future__ import annotations
 
 from collections import deque
 
-# Another approach to determine if a graph is a DAG is to try to perform a topological sort.
-# If the topological sort is successful (i.e., all vertices are visited exactly once),
-# the graph is a DAG. If the topological sort cannot include all vertices (i.e., the graph has a cycle),
-# it is not a DAG. Here is a basic implementation using Kahn's Algorithm:
-
 
 def is_dag(graph: dict[str, set[str]]) -> bool:
     """
-    Determine if a graph is a directed acyclic graph (DAG).
+    Determine if a graph is a directed acyclic graph (DAG) using topological sorting.
+
+    This function implements Kahn's algorithm for topological sorting to check
+    if the given graph is a DAG. A graph is a DAG if it has no directed cycles.
+    The algorithm works by repeatedly removing nodes with no incoming edges
+    and their outgoing edges. If all nodes can be removed this way, the graph
+    is a DAG; otherwise, it contains at least one cycle.
 
     Args:
-        graph: The graph to check.
+        graph: A dictionary representing the graph, where keys are node IDs and
+               values are sets of node IDs that the key node points to
 
     Returns:
-        Whether the graph is a DAG.
+        True if the graph is a DAG (has no cycles), False otherwise
+
+    Example:
+        ```python
+        # A simple linear graph (A -> B -> C)
+        graph = {"A": {"B"}, "B": {"C"}, "C": set()}
+        assert is_dag(graph) == True
+
+        # A graph with a cycle (A -> B -> C -> A)
+        graph = {"A": {"B"}, "B": {"C"}, "C": {"A"}}
+        assert is_dag(graph) == False
+        ```
     """
 
     in_degree = {u: 0 for u in graph}  # Initialize in-degree of each node to 0

--- a/src/ffmpeg/utils/escaping.py
+++ b/src/ffmpeg/utils/escaping.py
@@ -1,17 +1,39 @@
+"""
+Utilities for escaping special characters in FFmpeg command arguments.
+
+This module provides functions for properly escaping special characters in
+FFmpeg command-line arguments and converting Python dictionaries to FFmpeg
+command-line parameter formats.
+"""
+
 from collections.abc import Iterable
 from typing import Any
 
 
 def escape(text: str | int | float, chars: str = "\\'=:") -> str:
     """
-    Helper function to escape uncomfortable characters.
+    Escape special characters in a string for use in FFmpeg commands.
+
+    This function adds backslash escaping to specified characters in a string,
+    making it safe to use in FFmpeg filter strings and command-line arguments
+    where certain characters have special meaning.
 
     Args:
-        text: The text to escape.
-        chars: The characters to escape.
+        text: The text to escape (will be converted to string if not already)
+        chars: A string containing all characters that should be escaped
+               (default: "\\'=:" which handles most common special chars in FFmpeg)
 
     Returns:
-        The escaped text.
+        The input text with all specified characters escaped with backslashes
+
+    Example:
+        ```python
+        # Escape a filename with spaces for FFmpeg
+        safe_filename = escape("input file.mp4")  # "input\\ file.mp4"
+
+        # Escape a filter parameter value
+        safe_value = escape("key=value", "=:")  # "key\\=value"
+        ```
     """
     text = str(text)
     _chars = list(set(chars))
@@ -27,13 +49,31 @@ def escape(text: str | int | float, chars: str = "\\'=:") -> str:
 
 def convert_kwargs_to_cmd_line_args(kwargs: dict[str, Any]) -> list[str]:
     """
-    Helper function to build command line arguments out of dict.
+    Convert a Python dictionary to FFmpeg command-line arguments.
+
+    This function takes a dictionary of parameter names and values and converts
+    them to a list of strings in the format expected by FFmpeg command-line tools.
+    Each key becomes a parameter prefixed with '-', and its value follows as a
+    separate argument.
 
     Args:
-        kwargs: The dict to convert.
+        kwargs: Dictionary mapping parameter names to their values
 
     Returns:
-        The command line arguments.
+        A list of strings representing FFmpeg command-line arguments
+
+    Example:
+        ```python
+        args = convert_kwargs_to_cmd_line_args(
+            {"c:v": "libx264", "crf": 23, "preset": "medium"}
+        )
+        # Returns ['-c:v', 'libx264', '-crf', '23', '-preset', 'medium']
+        ```
+
+    Note:
+        If a value is None, only the parameter name is included.
+        If a value is an iterable (but not a string), the parameter is repeated
+        for each value in the iterable.
     """
     args = []
     for k in sorted(kwargs.keys()):

--- a/src/ffmpeg/utils/lazy_eval/operator.py
+++ b/src/ffmpeg/utils/lazy_eval/operator.py
@@ -1,3 +1,12 @@
+"""
+Concrete operator implementations for lazy evaluation expressions.
+
+This module defines the specific operator classes that implement the LazyOperator
+abstract base class. Each class represents a mathematical operation like addition,
+subtraction, multiplication, etc., and provides the implementation for evaluating
+that operation when all required values are available.
+"""
+
 from dataclasses import dataclass
 from typing import Any
 
@@ -7,13 +16,46 @@ from .schema import LazyOperator
 @dataclass(frozen=True, kw_only=True)
 class Add(LazyOperator):
     """
-    A lazy operator for addition.
+    A lazy operator for addition operations.
+
+    This class implements the addition operation for lazy evaluation expressions.
+    It evaluates to the sum of its left and right operands when all required
+    values are available.
+
+    Example:
+        ```python
+        # Create an expression that adds width and height
+        from .schema import Symbol
+
+        width = Symbol("width")
+        height = Symbol("height")
+        expr = Add(left=width, right=height)
+
+        # Evaluate the expression with specific values
+        result = expr.eval(width=1280, height=720)  # Returns 2000
+        ```
     """
 
     def _eval(self, left: Any, right: Any) -> Any:
+        """
+        Evaluate the addition operation with the given operands.
+
+        Args:
+            left: The left operand
+            right: The right operand
+
+        Returns:
+            The sum of the left and right operands
+        """
         return left + right
 
     def __str__(self) -> str:
+        """
+        Get a string representation of this addition operation.
+
+        Returns:
+            A string in the format "(left+right)"
+        """
         return f"({self.left}+{self.right})"
 
 

--- a/src/ffmpeg/utils/lazy_eval/schema.py
+++ b/src/ffmpeg/utils/lazy_eval/schema.py
@@ -1,3 +1,13 @@
+"""
+Schema for lazy evaluation of expressions in FFmpeg filter parameters.
+
+This module defines the core classes for lazy evaluation of expressions in
+FFmpeg filter parameters. It provides a way to represent expressions that
+can be evaluated at a later time, when all required values are available.
+This is particularly useful for parameters that depend on runtime information
+or need to be computed based on other parameters.
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -9,7 +19,15 @@ from ..typing import override
 
 class LazyValue(ABC):
     """
-    A base class for lazy evaluation.
+    Abstract base class for lazy evaluation of expressions.
+
+    LazyValue represents an expression that can be evaluated at a later time,
+    when all required values are available. It supports various arithmetic
+    operations, allowing complex expressions to be built and evaluated lazily.
+
+    This class serves as the foundation for the lazy evaluation system, with
+    concrete implementations like Symbol and LazyOperator providing specific
+    functionality.
     """
 
     def __add__(self, v: Any) -> LazyValue:
@@ -132,6 +150,14 @@ class LazyValue(ABC):
     def ready(self) -> bool:
         """
         Check if the lazy value is ready to be evaluated.
+
+        A lazy value is considered ready for evaluation when it doesn't require
+        any additional values to be provided. This is determined by checking if
+        the set of required keys is empty.
+
+        Returns:
+            True if the lazy value can be evaluated without additional values,
+            False otherwise
         """
         return not self.keys()
 
@@ -139,6 +165,14 @@ class LazyValue(ABC):
     def keys(self) -> set[str]:
         """
         Get the keys that are required to evaluate the lazy value.
+
+        This method returns the set of symbol names that must be provided
+        as values for the lazy value to be fully evaluated. For example,
+        if the lazy value represents the expression 'width * height',
+        this method would return {'width', 'height'}.
+
+        Returns:
+            A set of strings representing the required symbol names
         """
         ...
 
@@ -146,33 +180,80 @@ class LazyValue(ABC):
 @dataclass(frozen=True)
 class Symbol(LazyValue):
     """
-    A symbol that represents a variable in the lazy evaluation.
+    A symbol that represents a variable in lazy evaluation expressions.
 
-    Such as `x`, `y`, `z`, etc.
+    Symbol is a concrete implementation of LazyValue that represents a named
+    variable in an expression. When evaluating the expression, the actual value
+    of the symbol is provided through a dictionary of values.
+
+    Examples of symbols include variable names like 'width', 'height', or any
+    other parameter that will be provided at evaluation time rather than at
+    expression creation time.
+
+    Attributes:
+        key: The name of the variable this symbol represents
     """
 
     key: str
 
     def __str__(self) -> str:
+        """
+        Get a string representation of this symbol.
+
+        Returns:
+            The symbol's key as a string
+        """
         return str(self.key)
 
     @override
     def partial(self, **values: Any) -> Any:
+        """
+        Partially evaluate this symbol with the given values.
+
+        If the symbol's key is present in the values dictionary, returns the
+        corresponding value. Otherwise, returns the symbol itself (unchanged).
+
+        Args:
+            **values: Dictionary mapping symbol names to their values
+
+        Returns:
+            The value for this symbol if available, otherwise the symbol itself
+        """
         if self.key in values:
             return values[self.key]
         return self
 
     @override
     def keys(self) -> set[str]:
+        """
+        Get the set of symbol names required to evaluate this symbol.
+
+        For a Symbol, this is simply a set containing its own key.
+
+        Returns:
+            A set containing the symbol's key
+        """
         return {self.key}
 
 
 @dataclass(frozen=True, kw_only=True)
 class LazyOperator(LazyValue):
     """
-    A base class for lazy operators.
+    Abstract base class for operators in lazy evaluation expressions.
 
-    Such as `Add`, `Sub`, `Mul`, `TrueDiv`, `Pow`, `Neg`, `Pos`, `Abs`, `Mod`, `FloorDiv`.
+    LazyOperator is an abstract implementation of LazyValue that represents
+    mathematical operations in an expression. Concrete subclasses implement
+    specific operations like addition, subtraction, multiplication, etc.
+
+    This class provides the common structure and behavior for all operators,
+    including handling of operands that may themselves be LazyValues.
+
+    Attributes:
+        left: The left operand of the operation (or the only operand for unary operations)
+        right: The right operand of the operation (None for unary operations)
+
+    Concrete implementations include:
+        Add, Sub, Mul, TrueDiv, Pow, Neg, Pos, Abs, Mod, FloorDiv
     """
 
     left: Any = None
@@ -181,12 +262,37 @@ class LazyOperator(LazyValue):
     @abstractmethod
     def _eval(self, left: Any, right: Any) -> Any:
         """
-        Evaluate the operator with the given values.
+        Evaluate the operator with the given operand values.
+
+        This abstract method must be implemented by concrete operator subclasses
+        to define the specific operation to perform (e.g., addition, multiplication).
+
+        Args:
+            left: The evaluated left operand (or only operand for unary operations)
+            right: The evaluated right operand (may be None for unary operations)
+
+        Returns:
+            The result of applying the operation to the operands
         """
         ...
 
     @override
     def partial(self, **values: Any) -> Any:
+        """
+        Partially evaluate this operator with the given values.
+
+        This method recursively evaluates the operands (which may themselves be
+        LazyValues) with the provided values, then applies the operator's
+        specific operation to the results.
+
+        Args:
+            **values: Dictionary mapping symbol names to their values
+
+        Returns:
+            The result of applying the operation to the partially evaluated operands,
+            which may be a concrete value or another LazyValue if some symbols
+            remain unevaluated
+        """
         if isinstance(self.left, LazyValue):
             left = self.left.partial(**values)
         else:
@@ -201,6 +307,16 @@ class LazyOperator(LazyValue):
 
     @override
     def keys(self) -> set[str]:
+        """
+        Get the set of symbol names required to evaluate this operator.
+
+        This method collects the required symbol names from both operands
+        (if they are LazyValues) and returns their union.
+
+        Returns:
+            A set of strings representing all symbol names required to
+            fully evaluate this operator
+        """
         r = set()
         if isinstance(self.left, LazyValue):
             r |= self.left.keys()


### PR DESCRIPTION
This pull request includes comprehensive documentation updates to the `src/ffmpeg/common/schema.py` and `src/ffmpeg/common/serialize.py` files. The changes mainly involve adding detailed docstrings to classes, methods, and functions to improve code readability and maintainability.

### Documentation Enhancements:

* [`src/ffmpeg/common/schema.py`](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R1-R8): Added detailed docstrings to various classes and methods, such as `StreamType`, `FFMpegFilterOptionType`, `FFMpegFilterType`, `FFMpegFilterOptionChoice`, `FFMpegFilterOption`, `FFMpegIOType`, `FFMpegFilterDef`, `FFMpegFilter`, `FFMpegOptionFlag`, and `FFMpegOption`. These docstrings provide descriptions, usage examples, and explanations of parameters and return values. [[1]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R1-R8) [[2]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53L10-R41) [[3]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R61-R286) [[4]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R297-R308) [[5]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R333-R344) [[6]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R369-R384) [[7]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R495-R584) [[8]](diffhunk://#diff-d42cb63b53bea8e2f0c835aa2b8153aaa7ede093e5720c72fe8cfa49aba0ea53R593-R601)

* [`src/ffmpeg/common/serialize.py`](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fR1-R9): Added comprehensive docstrings to functions such as `load_class`, `frozen`, `object_hook`, `loads`, `to_dict_with_class_info`, and `dumps`. These docstrings explain the purpose of each function, their arguments, return values, and provide examples for better understanding. [[1]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fR1-R9) [[2]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL16-R49) [[3]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL37-R83) [[4]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL56-R118) [[5]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL79-R154) [[6]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL94-R182) [[7]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL130-R231)