### PR TITLE
fix #138 always use map even if there is only one output

### DIFF
--- a/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input.json
+++ b/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input.json
@@ -10,5 +10,7 @@
   "-nodisplay_vflip",
   "-i",
   "input.mp4",
+  "-map",
+  "0",
   "output.mp4"
 ]

--- a/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input_with_filter.json
+++ b/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input_with_filter.json
@@ -6,5 +6,7 @@
   "10",
   "-i",
   "anullsrc",
+  "-map",
+  "0",
   "output.mp4"
 ]

--- a/src/ffmpeg/dag/io/tests/__snapshots__/test_output/test_output.json
+++ b/src/ffmpeg/dag/io/tests/__snapshots__/test_output/test_output.json
@@ -2,6 +2,8 @@
   "ffmpeg",
   "-i",
   "input.mp4",
+  "-map",
+  "0",
   "-c",
   "copy",
   "-shortest",

--- a/src/ffmpeg/dag/nodes.py
+++ b/src/ffmpeg/dag/nodes.py
@@ -665,10 +665,7 @@ class OutputNode(Node):
         # !handle mapping
         commands = []
 
-        if context and (
-            any(isinstance(k.node, FilterNode) for k in self.inputs)
-            or len([k for k in context.all_nodes if isinstance(k, OutputNode)]) >= 1
-        ):
+        if context:
             for input in self.inputs:
                 if isinstance(input.node, InputNode):
                     commands += ["-map", input.label(context)]

--- a/src/ffmpeg/dag/nodes.py
+++ b/src/ffmpeg/dag/nodes.py
@@ -667,7 +667,7 @@ class OutputNode(Node):
 
         if context and (
             any(isinstance(k.node, FilterNode) for k in self.inputs)
-            or len([k for k in context.all_nodes if isinstance(k, OutputNode)]) > 1
+            or len([k for k in context.all_nodes if isinstance(k, OutputNode)]) >= 1
         ):
             for input in self.inputs:
                 if isinstance(input.node, InputNode):

--- a/src/ffmpeg/dag/tests/__snapshots__/test_nodes.ambr
+++ b/src/ffmpeg/dag/tests/__snapshots__/test_nodes.ambr
@@ -101,6 +101,8 @@
     '-nostdin',
     '-i',
     'tmp1.mp4',
+    '-map',
+    '0',
     'output.mp4',
   ])
 # ---

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_assemble_video_from_sequence_of_frames.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_assemble_video_from_sequence_of_frames.json
@@ -6,5 +6,7 @@
   "glob",
   "-i",
   "/path/to/jpegs/*.jpg",
+  "-map",
+  "0",
   "movie.mp4"
 ]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_concat_dumuxer.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_concat_dumuxer.json
@@ -8,5 +8,7 @@
   "file,http,https,tcp,tls",
   "-i",
   "files.txt",
+  "-map",
+  "0",
   "output.mp4"
 ]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_map.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_map.json
@@ -1,0 +1,18 @@
+[
+  "ffmpeg",
+  "-y",
+  "-i",
+  "input_video.mp4",
+  "-i",
+  "input_audio.mp3",
+  "-map",
+  "0:v",
+  "-map",
+  "1:a",
+  "-shortest",
+  "-vcodec",
+  "copy",
+  "-acodec",
+  "aac",
+  "output_video.mp4"
+]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_output_node.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_output_node.json
@@ -2,6 +2,8 @@
   "ffmpeg",
   "-i",
   "input1",
+  "-map",
+  "0",
   "-str",
   "x",
   "-int",

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -229,3 +229,26 @@ def test_source_filter(snapshot: SnapshotAssertion) -> None:
             in_file, color(color="red", size="hd1080"), filename="output.mp4"
         ).compile()
     )
+
+
+def test_map(snapshot: SnapshotAssertion) -> None:
+    input_video_file_path = "input_video.mp4"
+    input_audio_file_path = "input_audio.mp3"
+    output_video_file_path = "output_video.mp4"
+
+    video_stream = input(input_video_file_path).video
+    audio_stream = input(input_audio_file_path).audio
+
+    assert (
+        snapshot(extension_class=JSONSnapshotExtension)
+        == output(
+            video_stream,
+            audio_stream,
+            filename=output_video_file_path,
+            vcodec="copy",
+            acodec="aac",
+            shortest=True,
+        )
+        .overwrite_output()
+        .compile()
+    )


### PR DESCRIPTION
fix #138 current map will be complete ignore if there is only one output, which is not correct

This pull request includes a minor change to the `get_args` method in `src/ffmpeg/dag/nodes.py`. The condition for checking the number of `OutputNode` instances in the `context.all_nodes` list has been updated to trigger when there is at least one `OutputNode`, instead of requiring more than one.