### PR TITLE
fix #464 import issues while use typed-ffmpeg-compatible

### DIFF
--- a/src/ffmpeg/common/schema.py
+++ b/src/ffmpeg/common/schema.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Literal
 
-from ffmpeg.common.serialize import Serializable, serializable
+from .serialize import Serializable, serializable
 
 
 @serializable


### PR DESCRIPTION
fix #464

This pull request includes a minor change to the import statement in `src/ffmpeg/common/schema.py`. The change updates the import path for `Serializable` and `serializable` to use a relative import instead of an absolute one.