### PR TITLE
fix #467 pypi publish failed

### DIFF
--- a/.github/workflows/python-publish-compatible.yml
+++ b/.github/workflows/python-publish-compatible.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for publishing Python packages by modifying the version of the `pypa/gh-action-pypi-publish` action to use a stable release tag.

Updates to GitHub Actions workflows:

* [`.github/workflows/python-publish-compatible.yml`](diffhunk://#diff-060a1be5a3e63fd589de6420aff45e7e350a2aee4607ae4dbb94eaca49ecf26cL45-R45): Updated the `pypa/gh-action-pypi-publish` action from a specific commit hash to the `release/v1` tag for better maintainability and stability.
* [`.github/workflows/python-publish.yml`](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377L41-R41): Similarly updated the `pypa/gh-action-pypi-publish` action to use the `release/v1` tag.