### PR TITLE
Fix 484 use pre commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-pre-commit run
-npx lint-staged

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,8 +61,8 @@ repos:
         args: [--fix]
         additional_dependencies:
           - 'eslint@8.56.0'
-          - '@typescript-eslint/eslint-plugin@8.31.0'
-          - '@typescript-eslint/parser@8.31.0'
+          - '@typescript-eslint/eslint-plugin@6.21.0'
+          - '@typescript-eslint/parser@6.21.0'
           - 'eslint-plugin-react@7.37.5'
 
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,11 +39,42 @@ repos:
         types: [python]
         exclude: migrations/|commands/|sandbox/|samples|sdk
         additional_dependencies:
-          [pytest, syrupy, types-Pillow, typer, jinja2, types-beautifulsoup4, devtools, html2text]
+          - pytest
+          - syrupy
+          - types-Pillow
+          - typer
+          - jinja2
+          - types-beautifulsoup4
+          - devtools
+          - html2text
         args: ['--config-file=pyproject.toml']
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        name: ESLint
+        entry: eslint
+        language: node
+        types: [file]
+        files: ^ffmpeg-flow-editor/.*\.(js|jsx|ts|tsx)$
+        args: [--fix]
+        additional_dependencies:
+          - 'eslint@8.56.0'
+          - '@typescript-eslint/eslint-plugin@8.31.0'
+          - '@typescript-eslint/parser@8.31.0'
+          - 'eslint-plugin-react@7.37.5'
 
   - repo: local
     hooks:
+      - id: prettier
+        name: Prettier
+        entry: npx prettier
+        language: node
+        types: [file]
+        files: ^ffmpeg-flow-editor/.*\.(js|jsx|ts|tsx|json|md)$
+        args: [--write]
+
       - id: check-staged-tsx
         name: Check staged TypeScript files
         entry: bash -c 'git diff --cached --name-only --diff-filter=ACMR | grep "\.tsx$" | xargs -r eslint'

--- a/ffmpeg-flow-editor/README.md
+++ b/ffmpeg-flow-editor/README.md
@@ -28,15 +28,15 @@ export default tseslint.config({
       tsconfigRootDir: import.meta.dirname,
     },
   },
-})
+});
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default tseslint.config({
   plugins: {
@@ -50,5 +50,5 @@ export default tseslint.config({
     ...reactX.configs['recommended-typescript'].rules,
     ...reactDom.configs.recommended.rules,
   },
-})
+});
 ```

--- a/ffmpeg-flow-editor/eslint.config.js
+++ b/ffmpeg-flow-editor/eslint.config.js
@@ -1,8 +1,8 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -19,10 +19,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
-  },
-)
+  }
+);

--- a/ffmpeg-flow-editor/tsconfig.json
+++ b/ffmpeg-flow-editor/tsconfig.json
@@ -2,12 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable",
-      "ESNext"
-    ],
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "skipLibCheck": true,
     "resolveJsonModule": true,
@@ -22,16 +17,12 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"]
     },
     "noEmit": true,
     "types": ["node"]
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/ffmpeg-flow-editor/vite.config.ts
+++ b/ffmpeg-flow-editor/vite.config.ts
@@ -1,12 +1,12 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": "/src",
+      '@': '/src',
     },
   },
   server: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
         "@typescript-eslint/parser": "^8.31.0",
         "eslint": "^8.56.0",
         "eslint-plugin-react": "^7.37.5",
-        "husky": "^9.1.7",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5"
       }
@@ -1810,21 +1809,6 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
       "version": "5.0.0"
-    },
-    "node_modules/husky": {
-      "bin": {
-        "husky": "bin.js"
-      },
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      },
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "version": "9.1.7"
     },
     "node_modules/ignore": {
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "@typescript-eslint/parser": "^8.31.0",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.37.5",
-    "husky": "^9.1.7",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5"
   },
@@ -16,8 +15,5 @@
     "*.{json,md}": [
       "prettier --write"
     ]
-  },
-  "scripts": {
-    "prepare": "husky"
   }
 }


### PR DESCRIPTION
fix #484 

This pull request focuses on improving code consistency, enhancing linting and formatting tools, and removing unused dependencies. The most significant changes include the removal of Husky, the addition of Prettier and ESLint configurations, and the standardization of code style across multiple files.

### Tooling Updates:
* Removed Husky by deleting the `.husky/pre-commit` file and its associated `prepare` script in `package.json`. Pre-commit tasks are now managed directly through `lint-staged` and Prettier. [[1]](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL1-L3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-L21)
* Added ESLint and Prettier hooks to the `.pre-commit-config.yaml` file for improved linting and formatting of JavaScript, TypeScript, and JSON files.
* Removed the `husky` dependency from `package.json`.

### Code Style Standardization:
* Standardized import statements across multiple files by adding semicolons and ensuring consistent formatting in `eslint.config.js`, `vite.config.ts`, and `README.md`. [[1]](diffhunk://#diff-ad6b933fec9f5b34fac507c70f9dbc1216f3e948d73b690ac4b7b46191356eeaL1-R5) [[2]](diffhunk://#diff-449b3878bde9ee4a002d43a50e35d5d1cdfd94293a82d73a541c965459cf8e12L1-R9) [[3]](diffhunk://#diff-6b67db5cae335fa5710b21fc5399cd49544705bcb6c913a113d5f4992c3e14fcL31-R39)
* Updated TypeScript configuration in `tsconfig.json` to use a more compact format for `lib`, `paths`, and `include` properties. [[1]](diffhunk://#diff-af16e710c6662c3ef866101d8b894b890512df5ad27391e4f2bc9cdf86981c30L5-R5) [[2]](diffhunk://#diff-af16e710c6662c3ef866101d8b894b890512df5ad27391e4f2bc9cdf86981c30L25-R25)

### Linting Rules:
* Simplified the `react-refresh/only-export-components` rule configuration in `eslint.config.js` for better readability.