### PR TITLE
fix #477 correct show filter info

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,8 @@ repos:
           - '@typescript-eslint/eslint-plugin@6.21.0'
           - '@typescript-eslint/parser@6.21.0'
           - 'eslint-plugin-react@7.37.5'
+          - 'react@19.0.0'
+          - 'react-dom@19.0.0'
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,11 +61,16 @@ repos:
         args: [--fix]
         additional_dependencies:
           - 'eslint@8.56.0'
-          - '@typescript-eslint/eslint-plugin@6.21.0'
-          - '@typescript-eslint/parser@6.21.0'
+          - '@typescript-eslint/eslint-plugin@7.0.0'
+          - '@typescript-eslint/parser@7.0.0'
           - 'eslint-plugin-react@7.37.5'
           - 'react@19.0.0'
           - 'react-dom@19.0.0'
+          - '@emotion/react@11.14.0'
+          - '@emotion/styled@11.14.0'
+          - '@mui/material@7.0.2'
+          - '@mui/icons-material@7.0.2'
+          - 'typescript@5.3.3'
 
   - repo: local
     hooks:
@@ -76,6 +81,8 @@ repos:
         types: [file]
         files: ^ffmpeg-flow-editor/.*\.(js|jsx|ts|tsx|json|md)$
         args: [--write]
+        additional_dependencies:
+          - 'prettier@3.5.3'
 
       - id: check-staged-tsx
         name: Check staged TypeScript files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
 
       - id: check-staged-tsx
         name: Check staged TypeScript files
-        entry: bash -c 'git diff --cached --name-only --diff-filter=ACMR | grep "\.tsx$" | xargs -r eslint'
+        entry: bash -c 'cd ffmpeg-flow-editor && git diff --cached --name-only --diff-filter=ACMR | grep "\.tsx$" | sed "s|^ffmpeg-flow-editor/||" | xargs -r npx eslint'
         language: system
         types: [file]
         pass_filenames: false

--- a/ffmpeg-flow-editor/src/components/FilterNode.tsx
+++ b/ffmpeg-flow-editor/src/components/FilterNode.tsx
@@ -112,7 +112,7 @@ function FilterNode({ data, id }: NodeProps<FilterNodeData>) {
       {data.filterType === 'filter' && (
         <Box sx={{ mt: 1 }}>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-            {predefinedFilters.find((f) => f.name === data.filterName)?.description}
+            {predefinedFilters.find((f) => f.name === data.filterName)?.description ?? data.filterName ?? "No description available"}
           </Typography>
           {predefinedFilters
             .find((f) => f.name === data.filterName)

--- a/ffmpeg-flow-editor/src/components/FilterNode.tsx
+++ b/ffmpeg-flow-editor/src/components/FilterNode.tsx
@@ -111,8 +111,8 @@ function FilterNode({ data, id }: NodeProps<FilterNodeData>) {
       </Typography>
       {data.filterType === 'filter' && (
         <Box sx={{ mt: 1 }}>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            {data.filterName}
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+            {predefinedFilters.find((f) => f.name === data.filterName)?.description}
           </Typography>
           {predefinedFilters
             .find((f) => f.name === data.filterName)

--- a/ffmpeg-flow-editor/src/components/FilterNode.tsx
+++ b/ffmpeg-flow-editor/src/components/FilterNode.tsx
@@ -112,7 +112,9 @@ function FilterNode({ data, id }: NodeProps<FilterNodeData>) {
       {data.filterType === 'filter' && (
         <Box sx={{ mt: 1 }}>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-            {predefinedFilters.find((f) => f.name === data.filterName)?.description ?? data.filterName ?? "No description available"}
+            {predefinedFilters.find((f) => f.name === data.filterName)?.description ??
+              data.filterName ??
+              'No description available'}
           </Typography>
           {predefinedFilters
             .find((f) => f.name === data.filterName)

--- a/ffmpeg-flow-editor/src/components/Sidebar.tsx
+++ b/ffmpeg-flow-editor/src/components/Sidebar.tsx
@@ -124,7 +124,7 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
                   color="text.secondary"
                   sx={{ display: 'block', mt: 0.5 }}
                 >
-                  {filter.description}
+                  {filter.description ?? "No description available"}
                 </Typography>
               </Paper>
             ))}

--- a/ffmpeg-flow-editor/src/components/Sidebar.tsx
+++ b/ffmpeg-flow-editor/src/components/Sidebar.tsx
@@ -124,7 +124,7 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
                   color="text.secondary"
                   sx={{ display: 'block', mt: 0.5 }}
                 >
-                  {filter.description ?? "No description available"}
+                  {filter.description ?? 'No description available'}
                 </Typography>
               </Paper>
             ))}

--- a/ffmpeg-flow-editor/src/components/Sidebar.tsx
+++ b/ffmpeg-flow-editor/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper, Typography, Divider, TextField, InputAdornment } from '@mui/material';
 import { Node, Edge } from 'reactflow';
-import { FFmpegFilter, predefinedFilters } from '../types/ffmpeg';
+import { predefinedFilters } from '../types/ffmpeg';
 import PreviewPanel from './PreviewPanel';
 import { useState, useMemo } from 'react';
 import SearchIcon from '@mui/icons-material/Search';
@@ -119,8 +119,12 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
                 <Typography variant="body2" fontWeight={500}>
                   {filter.label}
                 </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {filter.name}
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: 'block', mt: 0.5 }}
+                >
+                  {filter.description}
                 </Typography>
               </Paper>
             ))}


### PR DESCRIPTION
fix #477 

This pull request introduces changes to enhance the user interface of the `ffmpeg-flow-editor` and updates the pre-commit configuration for TypeScript linting. The key updates include displaying filter descriptions instead of names in the UI and improving the pre-commit linting process.

### User Interface Enhancements:
* [`ffmpeg-flow-editor/src/components/FilterNode.tsx`](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L114-R115): Updated the `FilterNode` component to display the description of a filter (if available) instead of its name, using the `predefinedFilters` array. Adjusted the typography style for better readability.
* [`ffmpeg-flow-editor/src/components/Sidebar.tsx`](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3L122-R127): Modified the `Sidebar` component to show filter descriptions in place of filter names. Adjusted the typography to include spacing for improved layout.

### Pre-commit Configuration Update:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L80-R80): Updated the `check-staged-tsx` pre-commit hook to ensure TypeScript files are linted correctly within the `ffmpeg-flow-editor` directory. The command now strips the directory prefix before passing files to `eslint`.

### Code Cleanup:
* [`ffmpeg-flow-editor/src/components/Sidebar.tsx`](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3L3-R3): Removed the unused import of `FFmpegFilter` from the file to clean up the codebase.