### PR TITLE
fix #487 drag and drop filter

### DIFF
--- a/ffmpeg-flow-editor/src/components/Sidebar.tsx
+++ b/ffmpeg-flow-editor/src/components/Sidebar.tsx
@@ -8,7 +8,11 @@ import SearchIcon from '@mui/icons-material/Search';
 interface SidebarProps {
   nodes: Node[];
   edges: Edge[];
-  onAddFilter: (filterType: string, parameters?: Record<string, string>) => void;
+  onAddFilter: (
+    filterType: string,
+    parameters?: Record<string, string>,
+    position?: { x: number; y: number }
+  ) => void;
 }
 
 export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
@@ -25,6 +29,11 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
       )
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [searchQuery]);
+
+  const handleDragStart = (e: React.DragEvent, filterName: string) => {
+    e.dataTransfer.setData('application/reactflow', filterName);
+    e.dataTransfer.effectAllowed = 'move';
+  };
 
   return (
     <Paper
@@ -105,9 +114,12 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
               <Paper
                 key={filter.name}
                 elevation={0}
+                draggable
+                onDragStart={(e) => handleDragStart(e, filter.name)}
+                onClick={() => onAddFilter(filter.name)}
                 sx={{
                   p: 1.5,
-                  cursor: 'pointer',
+                  cursor: 'grab',
                   borderBottom: '1px solid',
                   borderColor: 'divider',
                   '&:last-child': {
@@ -116,8 +128,10 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
                   '&:hover': {
                     backgroundColor: '#f5f5f5',
                   },
+                  '&:active': {
+                    cursor: 'grabbing',
+                  },
                 }}
-                onClick={() => onAddFilter(filter.name)}
               >
                 <Typography variant="body2" fontWeight={500}>
                   {filter.name}


### PR DESCRIPTION
fix #487 

This pull request enhances the drag-and-drop functionality in the FFmpeg Flow Editor by introducing the ability to drag filters from the sidebar and drop them onto the canvas at a specific position. Key changes include updates to the `FFmpegFlowEditor` and `Sidebar` components to support this feature.

### Drag-and-Drop Functionality in `FFmpegFlowEditor`:

* Added a `reactFlowInstance` state to manage React Flow's instance and enable position calculations for dropped nodes (`[ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxR51](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R51)`).
* Updated the `onAddFilter` function to accept an optional `position` parameter for precise placement of new nodes (`[ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxL119-R132](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L119-R132)`).
* Introduced `onDragOver` and `onDrop` event handlers to handle drag-and-drop actions on the canvas. These calculate the drop position and add a new filter node accordingly (`[ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxR149-R175](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R149-R175)`).
* Registered the `onInit`, `onDragOver`, and `onDrop` handlers with the React Flow component (`[ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxR195-R197](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R195-R197)`).

### Drag-and-Drop Support in `Sidebar`:

* Updated the `onAddFilter` prop in `Sidebar` to include the optional `position` parameter for compatibility with the new drag-and-drop functionality (`[ffmpeg-flow-editor/src/components/Sidebar.tsxL11-R15](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3L11-R15)`).
* Added a `handleDragStart` function to initiate drag events for filters, setting the necessary data transfer properties (`[ffmpeg-flow-editor/src/components/Sidebar.tsxR33-R37](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3R33-R37)`).
* Made filter items draggable and updated their styles to reflect drag states, including `grab` and `grabbing` cursors (`[[1]](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3R117-R122)`, `[[2]](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3R131-L120)`).