### PR TITLE
fix #488 create new input / output

### DIFF
--- a/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
+++ b/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
@@ -94,12 +94,22 @@ export default function FFmpegFlowEditor() {
       return false;
     }
 
-    // Check if target handle is already connected
+    // For Input nodes (source), allow multiple outgoing connections
+    if (sourceNode.data.filterType === 'input') {
+      return true;
+    }
+
+    // For Output nodes (target), allow multiple incoming connections
+    if (targetNode.data.filterType === 'output') {
+      return true;
+    }
+
+    // For regular FilterNodes, check if target handle is already connected
     const targetHasConnection = edges.some(
       (edge) => edge.target === connection.target && edge.targetHandle === connection.targetHandle
     );
 
-    // Check if source handle is already connected
+    // For regular FilterNodes, check if source handle is already connected
     const sourceHasConnection = edges.some(
       (edge) => edge.source === connection.source && edge.sourceHandle === connection.sourceHandle
     );
@@ -123,6 +133,26 @@ export default function FFmpegFlowEditor() {
       parameters?: Record<string, string>,
       position?: { x: number; y: number }
     ) => {
+      // Handle input and output nodes
+      if (filterType === 'input' || filterType === 'output') {
+        const newNode: Node = {
+          id: `${filterType}-${Date.now()}`,
+          type: 'filter',
+          position: position || {
+            x: Math.random() * 500 + 200,
+            y: Math.random() * 300 + 100,
+          },
+          data: {
+            label: filterType === 'input' ? 'Input' : 'Output',
+            filterType: filterType,
+            filterString: filterType === 'input' ? '[0:v]' : '[outv]',
+          },
+        };
+        setNodes((nds) => [...nds, newNode]);
+        return;
+      }
+
+      // Handle regular filter nodes
       const filter = predefinedFilters.find((f) => f.name === filterType);
       if (!filter) return;
 

--- a/ffmpeg-flow-editor/src/components/Sidebar.tsx
+++ b/ffmpeg-flow-editor/src/components/Sidebar.tsx
@@ -4,6 +4,8 @@ import { predefinedFilters } from '../types/ffmpeg';
 import PreviewPanel from './PreviewPanel';
 import { useState, useMemo } from 'react';
 import SearchIcon from '@mui/icons-material/Search';
+import InputIcon from '@mui/icons-material/Input';
+import OutputIcon from '@mui/icons-material/Output';
 
 interface SidebarProps {
   nodes: Node[];
@@ -81,6 +83,79 @@ export default function Sidebar({ nodes, edges, onAddFilter }: SidebarProps) {
           },
         }}
       >
+        {/* I/O Nodes Section */}
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle1" gutterBottom>
+            I/O Nodes
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1,
+              mb: 2,
+            }}
+          >
+            <Paper
+              elevation={0}
+              draggable
+              onDragStart={(e) => handleDragStart(e, 'input')}
+              onClick={() => onAddFilter('input')}
+              sx={{
+                p: 1.5,
+                cursor: 'grab',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                '&:hover': {
+                  backgroundColor: '#f5f5f5',
+                },
+                '&:active': {
+                  cursor: 'grabbing',
+                },
+              }}
+            >
+              <InputIcon fontSize="small" />
+              <Typography variant="body2" fontWeight={500}>
+                Input Node
+              </Typography>
+            </Paper>
+            <Paper
+              elevation={0}
+              draggable
+              onDragStart={(e) => handleDragStart(e, 'output')}
+              onClick={() => onAddFilter('output')}
+              sx={{
+                p: 1.5,
+                cursor: 'grab',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                '&:hover': {
+                  backgroundColor: '#f5f5f5',
+                },
+                '&:active': {
+                  cursor: 'grabbing',
+                },
+              }}
+            >
+              <OutputIcon fontSize="small" />
+              <Typography variant="body2" fontWeight={500}>
+                Output Node
+              </Typography>
+            </Paper>
+          </Box>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
         {/* Filters Section */}
         <Box sx={{ mb: 3 }}>
           <Typography variant="subtitle1" gutterBottom>


### PR DESCRIPTION
fix #488 

This pull request introduces support for Input and Output nodes in the FFmpeg Flow Editor, allowing users to define source and target nodes with distinct behaviors. The changes include updates to the connection logic, node creation, and the sidebar UI to accommodate these new node types.

### Support for Input and Output Nodes:

* **Connection Logic Updates**:
  - Modified the connection validation logic to allow multiple outgoing connections for Input nodes and multiple incoming connections for Output nodes. Regular filter nodes retain their existing connection restrictions. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxL97-R112](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L97-R112))

* **Node Creation Enhancements**:
  - Implemented logic to handle the creation of Input and Output nodes with predefined labels (`Input` and `Output`) and filter strings (`[0:v]` for Input and `[outv]` for Output). These nodes are assigned unique IDs and random positions. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxR136-R155](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R136-R155))

### Sidebar UI Improvements:

* **New I/O Nodes Section**:
  - Added a dedicated section in the sidebar for Input and Output nodes, including draggable UI elements with icons (`InputIcon` and `OutputIcon`) and descriptive labels. Users can drag-and-drop or click to add these nodes to the flow editor. (`ffmpeg-flow-editor/src/components/Sidebar.tsx`, [ffmpeg-flow-editor/src/components/Sidebar.tsxR86-R158](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3R86-R158))

* **Icon Imports**:
  - Imported `InputIcon` and `OutputIcon` to visually represent the Input and Output nodes in the sidebar. (`ffmpeg-flow-editor/src/components/Sidebar.tsx`, [ffmpeg-flow-editor/src/components/Sidebar.tsxR7-R8](diffhunk://#diff-6eaf008f44a92c01153a9ebacf1628293709973e82f91329b259d0f657cc84d3R7-R8))