### PR TITLE
fix #493 update command builder to support multi I/O

### DIFF
--- a/ffmpeg-flow-editor/src/components/PreviewPanel.tsx
+++ b/ffmpeg-flow-editor/src/components/PreviewPanel.tsx
@@ -18,75 +18,117 @@ interface PreviewPanelProps {
 }
 
 function generateFFmpegCommand(nodes: Node[], edges: Edge[]): { python: string } {
-  const inputNode = nodes.find((n) => n.data.filterType === 'input');
-  const outputNode = nodes.find((n) => n.data.filterType === 'output');
+  // Find all input and output nodes
+  const inputNodes = nodes.filter((n) => n.data.filterType === 'input');
+  const outputNodes = nodes.filter((n) => n.data.filterType === 'output');
 
-  if (!inputNode || !outputNode) {
+  if (inputNodes.length === 0 || outputNodes.length === 0) {
     return {
       python: '',
     };
   }
 
-  // Build filter chain
-  const padNames: Record<string, string> = {};
-  let padCounter = 0;
-
-  // Assign pad names to each node
-  nodes.forEach((node) => {
-    if (node.data.filterType === 'filter') {
-      padNames[node.id] = `[${padCounter++}]`;
-    }
-  });
-
   // Generate Python code
   let pythonCode = 'import ffmpeg\n\n';
-  pythonCode += '(ffmpeg.input("input.mp4")\n';
 
-  // Sort filter nodes based on edges to maintain correct order
-  const sortedFilterNodes: Node[] = [];
-  let currentId = inputNode.id;
+  // Create input streams
+  const inputStreams = inputNodes.map((node, index) => {
+    return `input${index} = ffmpeg.input("input${index}.mp4")`;
+  });
 
-  while (true) {
-    const edge = edges.find((e) => e.source === currentId);
-    if (!edge) break;
+  pythonCode += inputStreams.join('\n') + '\n\n';
 
-    const nextNode = nodes.find((n) => n.id === edge.target);
-    if (!nextNode || nextNode.data.filterType !== 'filter') break;
+  // Track processed streams by node ID
+  const nodeStreams: Record<string, string> = {};
 
-    sortedFilterNodes.push(nextNode);
-    currentId = nextNode.id;
-  }
+  // Initialize with input streams
+  inputNodes.forEach((node, index) => {
+    nodeStreams[node.id] = `input${index}`;
+  });
 
-  // Add filters in order
-  sortedFilterNodes.forEach((node) => {
-    if (node.data.filterType === 'filter' && node.data.filterName) {
-      const filterName = node.data.filterName;
-      const parameters = (node.data.parameters as Record<string, string>) || {};
+  // Build filter chains for each input
+  inputNodes.forEach((inputNode) => {
+    let currentId = inputNode.id;
+    let currentStream = nodeStreams[currentId];
 
-      // Convert parameters to Python kwargs
-      const kwargs = Object.entries(parameters)
-        .filter(([, value]) => value !== '')
-        .map(([key, value]) => {
-          // Handle numeric values without quotes
-          if (!isNaN(Number(value))) {
-            return `${key}=${value}`;
-          }
-          // Handle boolean values
-          if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
-            return `${key}=${value.toLowerCase()}`;
-          }
-          // Handle string values with quotes
-          return `${key}="${value}"`;
-        })
-        .join(', ');
+    while (true) {
+      const edge = edges.find((e) => e.source === currentId);
+      if (!edge) break;
 
-      pythonCode += `    .${filterName}(${kwargs})\n`;
+      const nextNode = nodes.find((n) => n.id === edge.target);
+      if (!nextNode || nextNode.data.filterType !== 'filter') break;
+
+      if (nextNode.data.filterType === 'filter' && nextNode.data.filterName) {
+        const filterName = nextNode.data.filterName;
+        const parameters = (nextNode.data.parameters as Record<string, string>) || {};
+
+        // Convert parameters to Python kwargs
+        const kwargs = Object.entries(parameters)
+          .filter(([, value]) => value !== '')
+          .map(([key, value]) => {
+            // Handle numeric values without quotes
+            if (!isNaN(Number(value))) {
+              return `${key}=${value}`;
+            }
+            // Handle boolean values
+            if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
+              return `${key}=${value.toLowerCase()}`;
+            }
+            // Handle string values with quotes
+            return `${key}="${value}"`;
+          })
+          .join(', ');
+
+        // Create a new variable for the processed stream with valid Python identifier
+        const nodeId = nextNode.id.replace(/-/g, '_');
+        const newStreamName = `stream_${nodeId}`;
+        pythonCode += `${newStreamName} = ${currentStream}.${filterName}(${kwargs})\n`;
+        nodeStreams[nextNode.id] = newStreamName;
+        currentStream = newStreamName;
+      }
+
+      currentId = nextNode.id;
     }
   });
 
-  // Add output
-  pythonCode += '    .output(filename="output.mp4")\n';
-  pythonCode += '    .compile_line())';
+  pythonCode += '\n';
+
+  // Create output streams
+  outputNodes.forEach((node, index) => {
+    // Find all streams that connect to this output
+    const connectedStreams = edges
+      .filter((edge) => edge.target === node.id)
+      .map((edge) => {
+        const sourceNode = nodes.find((n) => n.id === edge.source);
+        if (!sourceNode) return null;
+        return nodeStreams[sourceNode.id];
+      })
+      .filter((stream): stream is string => stream !== null);
+
+    if (connectedStreams.length > 0) {
+      pythonCode += `output${index} = ffmpeg.output(${connectedStreams.join(', ')}, filename="output${index}.mp4")\n`;
+    }
+    // Skip output nodes with no connected streams
+  });
+
+  pythonCode += '\n';
+
+  // Add compile line
+  pythonCode += '# Compile the command\n';
+  const validOutputs = outputNodes
+    .map((node, index) => {
+      const hasConnections = edges.some((edge) => edge.target === node.id);
+      return hasConnections ? `output${index}` : null;
+    })
+    .filter((output): output is string => output !== null);
+
+  if (validOutputs.length > 1) {
+    pythonCode += `ffmpeg.merge_outputs(${validOutputs.join(', ')}).compile_line()`;
+  } else if (validOutputs.length === 1) {
+    pythonCode += `${validOutputs[0]}.compile_line()`;
+  } else {
+    pythonCode += '# No valid outputs to compile';
+  }
 
   return {
     python: pythonCode,


### PR DESCRIPTION
fix #493


This pull request refactors the `generateFFmpegCommand` function in `PreviewPanel.tsx` to improve its structure and functionality. The updates include better handling of input/output nodes, dynamic stream management, and enhanced Python code generation for FFmpeg commands.

### Refactoring and enhancements to `generateFFmpegCommand`:

* **Input and Output Node Handling**:
  - Replaced single input/output node selection with support for multiple input/output nodes, ensuring the function can handle more complex workflows.

* **Dynamic Stream Management**:
  - Introduced a `nodeStreams` mapping to dynamically track processed streams by node ID, enabling more flexible and maintainable stream handling.

* **Filter Chain Construction**:
  - Replaced the static filter node sorting logic with dynamic processing of filters directly within the loop, improving the clarity and flow of the code.

* **Python Code Generation**:
  - Updated the Python code generation to create uniquely named variables for processed streams, ensuring valid Python identifiers and avoiding naming conflicts.
  - Enhanced output stream handling to support multiple outputs and added logic to compile the command only for valid outputs.