### PR TITLE
fix #491 sepereate differnt stream type

### DIFF
--- a/ffmpeg-flow-editor/src/types/edge.ts
+++ b/ffmpeg-flow-editor/src/types/edge.ts
@@ -1,0 +1,11 @@
+export type EdgeType = 'av' | 'audio' | 'video';
+
+export const EDGE_COLORS = {
+  av: '#9c27b0', // Purple
+  audio: '#2196f3', // Blue
+  video: '#f44336', // Red
+} as const;
+
+export interface EdgeData {
+  type: EdgeType;
+}


### PR DESCRIPTION
fix #491

This pull request introduces enhancements to the FFmpeg Flow Editor to support multiple edge types (`av`, `audio`, `video`) and their corresponding visual distinctions. It also improves the handling of node connections by validating compatibility based on edge types. Below are the key changes grouped by theme:

### Edge Type Support and Styling
* Added a new `EdgeType` type and `EDGE_COLORS` constant to define and style edge types (`av`, `audio`, `video`) in `ffmpeg-flow-editor/src/types/edge.ts`.
* Updated `FilterNode` input and output handles to dynamically assign colors based on edge types using the `getHandleType` helper function. [[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L123-R151) [[2]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L193-R222)

### Connection Validation and Edge Creation
* Enhanced connection validation to check compatibility between source and target handle types, allowing only compatible edge types to connect. [[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R100-R103) [[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L118-R163)
* Modified the `onConnect` function to dynamically determine the edge type based on the source and target nodes, applying the appropriate style and metadata.

### Node Data Enhancements
* Added a `parameters` field to the initial nodes (`Input`, `Output`) and dynamically created nodes to store additional metadata. [[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R33) [[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R44) [[3]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R185)

### Helper Functions and Type Enhancements
* Introduced the `isIOType` helper function to determine the type of input/output (e.g., `audio`, `video`).
* Updated `FilterNode` to derive input and output types from filter definitions, replacing the previous fixed number of inputs/outputs with dynamically typed connections.

These changes collectively improve the flexibility and usability of the FFmpeg Flow Editor by introducing type-aware connections and visually distinguishing edge types.
