### PR TITLE
Fix 479 dynamic io 2

### DIFF
--- a/ffmpeg-flow-editor/src/types/ffmpeg.ts
+++ b/ffmpeg-flow-editor/src/types/ffmpeg.ts
@@ -14,8 +14,8 @@ export interface FFmpegFilter {
   is_filter_source: boolean;
   is_dynamic_input: boolean;
   is_dynamic_output: boolean;
-  stream_typings_input: FFmpegIOType[];
-  stream_typings_output: FFmpegIOType[];
+  stream_typings_input: FFmpegIOType[] | null;
+  stream_typings_output: FFmpegIOType[] | null;
   formula_typings_input: string | null;
   formula_typings_output: string | null;
   pre: unknown[];


### PR DESCRIPTION
fix #479 dynamic io 

This pull request introduces dynamic input and output type evaluation for filter nodes in the `ffmpeg-flow-editor` application, improving flexibility and error handling. It also refines the UI to display dynamic type formulas and error messages. Below are the most important changes:

### Dynamic Type Handling
* Added dynamic evaluation of input and output types based on formulas defined in the filter metadata. This includes parsing parameters and updating node internals when dynamic types are calculated. (`[[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91R35-R80)`, `[[2]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L107-R164)`)
* Updated the `FFmpegFilter` interface to allow `stream_typings_input` and `stream_typings_output` to be `null`, reflecting the optional nature of static type definitions. (`[ffmpeg-flow-editor/src/types/ffmpeg.tsL17-R18](diffhunk://#diff-386a79640544b3ee0c7e5acd66755062837fbc18ea093820e668fc0f546a640fL17-R18)`)

### Error Handling
* Introduced a `formulaError` state to capture and display errors encountered during dynamic type evaluation. (`[[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91R22-R25)`, `[[2]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L156-R251)`)
* Updated the UI to highlight nodes with errors by changing the border color and displaying error messages. (`[[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L156-R251)`, `[[2]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L236-L278)`)

### UI Enhancements
* Improved the layout by adding a `Typography` element for the node label and dynamic type formulas, and adjusted the maximum width of nodes. (`[ffmpeg-flow-editor/src/components/FilterNode.tsxL156-R251](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L156-R251)`)
* Simplified and streamlined the rendering of input and output handles, removing redundant console logs and code duplication. (`[[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L156-R251)`, `[[2]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L236-L278)`)