### PR TITLE
ref #518 remove strict options in serialize

### DIFF
--- a/src/ffmpeg/common/cache.py
+++ b/src/ffmpeg/common/cache.py
@@ -23,7 +23,7 @@ def load(cls: type[T], id: str) -> T:
     path = cache_path / f"{cls.__name__}/{id}.json"
 
     with path.open() as ifile:
-        obj = loads(ifile.read(), strict=False)
+        obj = loads(ifile.read())
         return obj
 
 

--- a/src/ffmpeg/common/serialize.py
+++ b/src/ffmpeg/common/serialize.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 from dataclasses import fields, is_dataclass
 from enum import Enum
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -109,7 +108,7 @@ def frozen(v: Any) -> Any:
     return v
 
 
-def object_hook(obj: Any, strict: bool = True) -> Any:
+def object_hook(obj: Any) -> Any:
     """
     Custom JSON object hook for deserializing FFmpeg objects.
 
@@ -119,7 +118,6 @@ def object_hook(obj: Any, strict: bool = True) -> Any:
 
     Args:
         obj: A dictionary from the JSON parser
-        strict: If True, only allow loading classes from the ffmpeg package
 
     Returns:
         Either the original dictionary or an instance of the specified class
@@ -148,7 +146,7 @@ def object_hook(obj: Any, strict: bool = True) -> Any:
     return obj
 
 
-def loads(raw: str, strict: bool = True) -> Any:
+def loads(raw: str) -> Any:
     """
     Deserialize a JSON string into Python objects with proper class types.
 
@@ -158,7 +156,6 @@ def loads(raw: str, strict: bool = True) -> Any:
 
     Args:
         raw: The JSON string to deserialize
-        strict: If True, only allow loading classes from the ffmpeg package
 
     Returns:
         The deserialized Python object with proper types
@@ -171,9 +168,7 @@ def loads(raw: str, strict: bool = True) -> Any:
         # filter_node is now a FilterNode instance
         ```
     """
-    object_hook_strict = partial(object_hook, strict=strict)
-
-    return json.loads(raw, object_hook=object_hook_strict)
+    return json.loads(raw, object_hook=object_hook)
 
 
 def to_dict_with_class_info(instance: Any) -> Any:


### PR DESCRIPTION
This pull request simplifies the JSON deserialization logic in the `ffmpeg` module by removing the `strict` parameter from several functions and their associated logic. The changes streamline the code and reduce unnecessary complexity.

### Simplifications to JSON deserialization:

* [`src/ffmpeg/common/cache.py`](diffhunk://#diff-7ceaa96abac21f0fee45963dc2e39723dd23c39550b33db959644ac4372bf1e6L26-R26): Removed the `strict` parameter when calling the `loads` function in the `load` method.
* [`src/ffmpeg/common/serialize.py`](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL112-R111): Removed the `strict` parameter from the `object_hook` function, simplifying its signature and documentation. [[1]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL112-R111) [[2]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL122)
* [`src/ffmpeg/common/serialize.py`](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL151-R149): Removed the `strict` parameter from the `loads` function, simplifying its signature, documentation, and internal logic by eliminating the use of `partial` for `object_hook`. [[1]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL151-R149) [[2]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL161) [[3]](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL174-R171)

### Code cleanup:

* [`src/ffmpeg/common/serialize.py`](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fL15): Removed an unused import for `functools.partial`.