### PR TITLE
ref: #518 update docstrings

### DIFF
--- a/src/ffmpeg/common/serialize.py
+++ b/src/ffmpeg/common/serialize.py
@@ -29,9 +29,8 @@ def serializable(
     """
     Register a class with the serialization system.
 
-    This function is used to register classes with the serialization system.
-    It's used by the `serializable` decorator to register classes with the
-    serialization system.
+    This function is used by the `serializable` decorator to register classes
+    with the serialization system, enabling them to be serialized and deserialized.
 
     Args:
         cls: The class to register

--- a/src/ffmpeg/common/serialize.py
+++ b/src/ffmpeg/common/serialize.py
@@ -28,6 +28,16 @@ def serializable(
 ) -> type[Serializable] | type[Enum]:
     """
     Register a class with the serialization system.
+
+    This function is used to register classes with the serialization system.
+    It's used by the `serializable` decorator to register classes with the
+    serialization system.
+
+    Args:
+        cls: The class to register
+
+    Returns:
+        The class itself
     """
     assert cls.__name__ not in CLASS_REGISTRY, (
         f"Class {cls.__name__} already registered"


### PR DESCRIPTION
This pull request includes a documentation update to the `serializable` function in `src/ffmpeg/common/serialize.py`. The update adds a detailed docstring explaining the function's purpose, usage, arguments, and return value.

Documentation improvements:

* [`src/ffmpeg/common/serialize.py`](diffhunk://#diff-c7c7013d8151b81f35ba2a3e74a50be34f4ff046c2b405b48c0c61bb719f0b5fR31-R40): Enhanced the docstring for the `serializable` function to describe its role in registering classes with the serialization system, specify the `cls` argument, and clarify the return value.