### PR TITLE
Fix 518 refactor context

### DIFF
--- a/src/ffmpeg/compile/context.py
+++ b/src/ffmpeg/compile/context.py
@@ -206,6 +206,24 @@ class DAGContext:
         return outgoing_streams
 
     @cached_property
+    def node_ids(self) -> dict[Node, int]:
+        """
+        Get a mapping of nodes to their unique integer IDs.
+        This property assigns a unique integer ID to each node in the graph,
+        based on the node type and its position in the processing chain.
+        Returns:
+            A dictionary mapping nodes to their unique integer IDs
+        """
+        node_index: dict[type[Node], int] = defaultdict(int)
+        node_ids: dict[Node, int] = {}
+
+        for node in sorted(self.nodes, key=lambda node: node.max_depth):
+            node_ids[node] = node_index[node.__class__]
+            node_index[node.__class__] += 1
+
+        return node_ids
+
+    @cached_property
     def node_labels(self) -> dict[Node, str]:
         """
         Get a mapping of nodes to their string labels used in FFmpeg filter graphs.

--- a/src/ffmpeg/compile/context.py
+++ b/src/ffmpeg/compile/context.py
@@ -21,7 +21,7 @@ from ..utils.typing import override
 T = TypeVar("T")
 
 
-def _remove_duplicates(seq: list[T]) -> list[T]:
+def _remove_duplicates(seq: tuple[T, ...]) -> tuple[T, ...]:
     """
     Remove duplicates from a list while preserving the original order.
 
@@ -36,17 +36,17 @@ def _remove_duplicates(seq: list[T]) -> list[T]:
         A new list with duplicates removed, preserving the original order
     """
     seen = set()
-    output = []
+    output: tuple[T, ...] = ()
 
     for x in seq:
         if x not in seen:
-            output.append(x)
+            output += (x,)
             seen.add(x)
 
     return output
 
 
-def _collect(node: Node) -> tuple[list[Node], list[Stream]]:
+def _collect(node: Node) -> tuple[tuple[Node, ...], tuple[Stream, ...]]:
     """
     Recursively collect all nodes and streams in the upstream path of a given node.
 
@@ -62,7 +62,8 @@ def _collect(node: Node) -> tuple[list[Node], list[Stream]]:
         - A list of all nodes in the upstream path (including the starting node)
         - A list of all streams connecting these nodes
     """
-    nodes, streams = [node], [*node.inputs]
+    nodes: tuple[Node, ...] = (node,)
+    streams: tuple[Stream, ...] = node.inputs
 
     for stream in node.inputs:
         _nodes, _streams = _collect(stream.node)
@@ -127,8 +128,8 @@ class DAGContext:
 
         return cls(
             node=node,
-            nodes=tuple(_remove_duplicates(nodes)),
-            streams=tuple(_remove_duplicates(streams)),
+            nodes=_remove_duplicates(nodes),
+            streams=_remove_duplicates(streams),
         )
 
     @cached_property

--- a/src/ffmpeg/compile/tests/__snapshots__/test_context.ambr
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_context.ambr
@@ -16,6 +16,15 @@
     'Stream(Node(concat#s2)#0)',
   ])
 # ---
+# name: test_context[node_ids]
+  dict({
+    'Node(concat#s2)': 2,
+    'Node(input1.mp4#0)': 0,
+    'Node(reverse#s0)': 0,
+    'Node(tmp.mp4#out)': 0,
+    'Node(trim#s1)': 1,
+  })
+# ---
 # name: test_context[node_labels]
   dict({
     'Node(concat#s2)': 's2',

--- a/src/ffmpeg/compile/tests/test_context.py
+++ b/src/ffmpeg/compile/tests/test_context.py
@@ -18,6 +18,7 @@ def test_context(snapshot: SnapshotAssertion) -> None:
     assert snapshot(name="outgoing_nodes") == context.render(context.outgoing_nodes)
     assert snapshot(name="outgoing_streams") == context.render(context.outgoing_streams)
     assert snapshot(name="node_labels") == context.render(context.node_labels)
+    assert snapshot(name="node_ids") == context.render(context.node_ids)
 
     assert context.get_node_label(input1.node) == "0"
     assert context.get_outgoing_streams(input1.node) == [input1]


### PR DESCRIPTION
This pull request focuses on transitioning from mutable lists to immutable tuples for better immutability and performance in the `src/ffmpeg/compile/context.py` file. Additionally, it introduces a new `node_ids` property to assign unique IDs to nodes in the graph. These changes improve code robustness and enhance the functionality of the `DAGContext` class.

### Transition to Tuples for Immutability and Performance:
* Changed `_remove_duplicates` to accept and return tuples instead of lists, ensuring immutability and aligning with the new data structure conventions.
* Updated `_collect` to use tuples for `nodes` and `streams` instead of lists, improving immutability and consistency across the code. [[1]](diffhunk://#diff-8262f9c7cafea3af547ea63aa5ef3c140eceb58239a45dc5852c0280dffea210L39-R49) [[2]](diffhunk://#diff-8262f9c7cafea3af547ea63aa5ef3c140eceb58239a45dc5852c0280dffea210L65-R66)
* Simplified the `build` method of `DAGContext` by removing redundant tuple conversions, as `_remove_duplicates` now directly returns tuples.

### New Functionality:
* Added a `node_ids` cached property to `DAGContext`, which generates a mapping of nodes to unique integer IDs based on their type and position in the graph. This provides a useful mechanism for uniquely identifying nodes in the graph structure.