### PR TITLE
ref #518 move DAGContext.render to tests

### DIFF
--- a/src/ffmpeg/compile/context.py
+++ b/src/ffmpeg/compile/context.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from ..dag.nodes import FilterNode, InputNode
 from ..dag.schema import Node, Stream
@@ -294,9 +294,6 @@ class DAGContext:
             AssertionError: If the node is not an InputNode or FilterNode
         """
 
-        assert isinstance(node, (InputNode, FilterNode)), (
-            "Only input and filter nodes have labels"
-        )
         return self.node_labels[node]
 
     @override
@@ -316,39 +313,3 @@ class DAGContext:
             A list of streams that originate from this node
         """
         return self.outgoing_streams[node]
-
-    def render(self, obj: Any) -> Any:
-        """
-        Recursively convert graph objects to a human-readable representation.
-
-        This method processes arbitrary objects, with special handling for graph
-        elements like nodes and streams. It converts them to a readable string format
-        that includes node labels. It recursively handles nested structures like
-        lists, tuples, and dictionaries.
-
-        This is primarily used for debugging, logging, and visualization purposes.
-
-        Args:
-            obj: The object to render, which may be a Node, Stream, or a container
-                 with these objects nested inside
-
-        Returns:
-            The rendered representation of the object:
-            - For nodes: "Node(repr#label)"
-            - For streams: "Stream(node_repr#label#index)"
-            - For containers: recursively rendered contents
-            - For other objects: the original object unchanged
-        """
-
-        if isinstance(obj, (list, tuple)):
-            return [self.render(o) for o in obj]
-        elif isinstance(obj, dict):
-            return {self.render(k): self.render(v) for k, v in obj.items()}
-
-        if isinstance(obj, Node):
-            return f"Node({obj.repr()}#{self.node_labels[obj]})"
-
-        if isinstance(obj, Stream):
-            return f"Stream({self.render(obj.node)}#{obj.index})"
-
-        return obj

--- a/src/ffmpeg/compile/tests/test_context.py
+++ b/src/ffmpeg/compile/tests/test_context.py
@@ -1,8 +1,46 @@
+from typing import Any
+
 from syrupy.assertion import SnapshotAssertion
 
 from ...base import input
+from ...dag.schema import Node, Stream
 from ...filters import concat
 from ..context import DAGContext
+
+
+def render(context: DAGContext, obj: Any) -> Any:
+    """
+    Recursively convert graph objects to a human-readable representation.
+    This method processes arbitrary objects, with special handling for graph
+    elements like nodes and streams. It converts them to a readable string format
+
+
+    that includes node labels. It recursively handles nested structures like
+    lists, tuples, and dictionaries.
+    This is primarily used for debugging, logging, and visualization purposes.
+    Args:
+        obj: The object to render, which may be a Node, Stream, or a container
+            with these objects nested inside
+    Returns:
+        The rendered representation of the object:
+        - For nodes: "Node(repr#label)"
+        - For streams: "Stream(node_repr#label#index)"
+        - For containers: recursively rendered contents
+        - For other objects: the original object unchanged
+    """
+
+    if isinstance(obj, (list, tuple)):
+        return [render(context, o) for o in obj]
+    elif isinstance(obj, dict):
+        return {render(context, k): render(context, v) for k, v in obj.items()}
+
+    if isinstance(obj, Node):
+        return f"Node({obj.repr()}#{context.get_node_label(obj)})"
+
+    if isinstance(obj, Stream):
+        return f"Stream({render(context, obj.node)}#{obj.index})"
+
+    return obj
 
 
 def test_context(snapshot: SnapshotAssertion) -> None:
@@ -12,13 +50,15 @@ def test_context(snapshot: SnapshotAssertion) -> None:
 
     context = DAGContext.build(stream.node)
 
-    assert snapshot(name="all_nodes") == context.render(context.all_nodes)
-    assert snapshot(name="all_streams") == context.render(context.all_streams)
+    assert snapshot(name="all_nodes") == render(context, context.all_nodes)
+    assert snapshot(name="all_streams") == render(context, context.all_streams)
 
-    assert snapshot(name="outgoing_nodes") == context.render(context.outgoing_nodes)
-    assert snapshot(name="outgoing_streams") == context.render(context.outgoing_streams)
-    assert snapshot(name="node_labels") == context.render(context.node_labels)
-    assert snapshot(name="node_ids") == context.render(context.node_ids)
+    assert snapshot(name="outgoing_nodes") == render(context, context.outgoing_nodes)
+    assert snapshot(name="outgoing_streams") == render(
+        context, context.outgoing_streams
+    )
+    assert snapshot(name="node_labels") == render(context, context.node_labels)
+    assert snapshot(name="node_ids") == render(context, context.node_ids)
 
     assert context.get_node_label(input1.node) == "0"
     assert context.get_outgoing_streams(input1.node) == [input1]


### PR DESCRIPTION
This pull request refactors the `DAGContext` class in the `src/ffmpeg/compile/context.py` file to simplify its implementation by removing the `render` method and moving its functionality to the test suite. Additionally, it updates the test suite to use the new standalone `render` function. Minor cleanups were also made to the imports and assertions in the code.

### Refactoring of `DAGContext`:

* Removed the `render` method from the `DAGContext` class, which was responsible for converting graph objects into a human-readable format. This functionality is now implemented as a standalone function in the test suite. (`src/ffmpeg/compile/context.py`, [src/ffmpeg/compile/context.pyL319-L354](diffhunk://#diff-8262f9c7cafea3af547ea63aa5ef3c140eceb58239a45dc5852c0280dffea210L319-L354))

### Updates to the test suite:

* Added a standalone `render` function in `src/ffmpeg/compile/tests/test_context.py` to replace the removed `render` method from `DAGContext`. Updated all test cases to use this new function for rendering objects. (`src/ffmpeg/compile/tests/test_context.py`, [src/ffmpeg/compile/tests/test_context.pyR1-R61](diffhunk://#diff-9bacf61d5ef1a993ba3afd159d37d39281bd1ddbdc76befba91bd9c3e4e280b7R1-R61))

### Code cleanup:

* Removed an unused import of `Any` from `src/ffmpeg/compile/context.py` to improve code clarity. (`src/ffmpeg/compile/context.py`, [src/ffmpeg/compile/context.pyL16-R16](diffhunk://#diff-8262f9c7cafea3af547ea63aa5ef3c140eceb58239a45dc5852c0280dffea210L16-R16))
* Eliminated an unnecessary assertion in the `get_node_label` method, as the method now assumes valid input. (`src/ffmpeg/compile/context.py`, [src/ffmpeg/compile/context.pyL297-L299](diffhunk://#diff-8262f9c7cafea3af547ea63aa5ef3c140eceb58239a45dc5852c0280dffea210L297-L299))