### PR TITLE
fix #518 refactor get_args

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -9,8 +9,12 @@ handling global options, inputs, complex filtergraphs, and outputs.
 
 from __future__ import annotations
 
-from ..dag.nodes import FilterNode, GlobalNode, InputNode, OutputNode
-from ..dag.schema import Stream
+from ..dag.nodes import FilterableStream, FilterNode, GlobalNode, InputNode, OutputNode
+from ..dag.schema import Node, Stream
+from ..exceptions import FFMpegValueError
+from ..schema import Default
+from ..utils.escaping import escape
+from ..utils.lazy_eval.schema import LazyValue
 from .context import DAGContext
 from .validate import validate
 
@@ -61,19 +65,19 @@ def compile(stream: Stream, auto_fix: bool = True) -> list[str]:
     commands = []
     global_nodes = [node for node in context.all_nodes if isinstance(node, GlobalNode)]
     for node in global_nodes:
-        commands += node.get_args(context)
+        commands += get_args(node, context)
 
     # compile the input nodes
     input_nodes = [node for node in context.all_nodes if isinstance(node, InputNode)]
     for node in input_nodes:
-        commands += node.get_args(context)
+        commands += get_args(node, context)
 
     # compile the filter nodes
     vf_commands = []
     filter_nodes = [node for node in context.all_nodes if isinstance(node, FilterNode)]
 
     for node in sorted(filter_nodes, key=lambda node: len(node.upstream_nodes)):
-        vf_commands += ["".join(node.get_args(context))]
+        vf_commands += ["".join(get_args(node, context))]
 
     if vf_commands:
         commands += ["-filter_complex", ";".join(vf_commands)]
@@ -81,6 +85,267 @@ def compile(stream: Stream, auto_fix: bool = True) -> list[str]:
     # compile the output nodes
     output_nodes = [node for node in context.all_nodes if isinstance(node, OutputNode)]
     for node in output_nodes:
-        commands += node.get_args(context)
+        commands += get_args(node, context)
 
     return commands
+
+
+def get_stream_label(stream: Stream, context: DAGContext | None = None) -> str:
+    """
+    Generate the FFmpeg label for this stream in filter graphs.
+
+    This method creates the label string used to identify this stream in
+    FFmpeg filter graphs. The format of the label depends on the stream's
+    source (input file or filter) and type (video or audio).
+
+    For input streams, labels follow FFmpeg's stream specifier syntax:
+    - Video streams: "0:v" (first input, video stream)
+    - Audio streams: "0:a" (first input, audio stream)
+    - AV streams: "0" (first input, all streams)
+
+    For filter outputs, labels use the filter's label:
+    - Single output filters: "filterlabel"
+    - Multi-output filters: "filterlabel#index"
+
+    Args:
+        context: Optional DAG context for resolving node labels.
+                If not provided, a new context will be built.
+
+    Returns:
+        A string label for this stream in FFmpeg filter syntax
+
+    Raises:
+        FFMpegValueError: If the stream has an unknown type or node type
+    """
+    from ..streams.audio import AudioStream
+    from ..streams.av import AVStream
+    from ..streams.video import VideoStream
+
+    if not context:
+        context = DAGContext.build(stream.node)
+
+    match stream.node:
+        case InputNode():
+            match stream:
+                case AVStream():
+                    return f"{get_node_label(stream.node, context)}"
+                case VideoStream():
+                    return f"{get_node_label(stream.node, context)}:v"
+                case AudioStream():
+                    return f"{get_node_label(stream.node, context)}:a"
+                case _:
+                    raise FFMpegValueError(
+                        f"Unknown stream type: {stream.__class__.__name__}"
+                    )  # pragma: no cover
+        case FilterNode():
+            if len(stream.node.output_typings) > 1:
+                return f"{get_node_label(stream.node, context)}#{stream.index}"
+            return f"{get_node_label(stream.node, context)}"
+        case _:
+            raise FFMpegValueError(
+                f"Unknown node type: {stream.node.__class__.__name__}"
+            )  # pragma: no cover
+
+
+def get_args_filter_node(node: FilterNode, context: DAGContext) -> list[str]:
+    """
+    Generate the FFmpeg filter string for this filter node.
+
+    This method creates the filter string that will be used in the
+    filter_complex argument of the FFmpeg command. The format follows
+    FFmpeg's syntax where input labels are followed by the filter name
+    and parameters, and then output labels.
+
+    Args:
+        context: Optional DAG context for resolving stream labels.
+                If not provided, a new context will be built.
+
+    Returns:
+        A list of strings that, when joined, form the filter string
+        for this node in the filter_complex argument
+
+    Example:
+        For a scale filter with width=1280 and height=720, this might return:
+        ['[0:v]', 'scale=', 'width=1280:height=720', '[s0]']
+    """
+
+    incoming_labels = "".join(f"[{get_stream_label(k, context)}]" for k in node.inputs)
+    outputs = context.get_outgoing_streams(node)
+
+    outgoing_labels = ""
+    for output in sorted(outputs, key=lambda stream: stream.index or 0):
+        # NOTE: all outgoing streams must be filterable
+        assert isinstance(output, FilterableStream)
+        outgoing_labels += f"[{get_stream_label(output, context)}]"
+
+    commands = []
+    for key, value in node.kwargs.items():
+        assert not isinstance(value, LazyValue), (
+            f"LazyValue should have been evaluated: {key}={value}"
+        )
+
+        # Note: the -nooption syntax cannot be used for boolean AVOptions, use -option 0/-option 1.
+        if isinstance(value, bool):
+            value = str(int(value))
+
+        if not isinstance(value, Default):
+            commands += [f"{key}={escape(value)}"]
+
+    if commands:
+        return (
+            [incoming_labels]
+            + [f"{node.name}="]
+            + [escape(":".join(commands), "\\'[],;")]
+            + [outgoing_labels]
+        )
+    return [incoming_labels] + [f"{node.name}"] + [outgoing_labels]
+
+
+def get_args_input_node(node: InputNode, context: DAGContext) -> list[str]:
+    """
+    Generate the FFmpeg command-line arguments for this input file.
+
+    This method creates the command-line arguments needed to specify
+    this input file to FFmpeg, including any input-specific options.
+
+    Args:
+        context: Optional DAG context (not used for input nodes)
+
+    Returns:
+        A list of strings representing FFmpeg command-line arguments
+
+    Example:
+        For an input file "input.mp4" with options like seeking to 10 seconds:
+        ['-ss', '10', '-i', 'input.mp4']
+    """
+    commands = []
+    for key, value in node.kwargs.items():
+        if isinstance(value, bool):
+            if value is True:
+                commands += [f"-{key}"]
+            elif value is False:
+                commands += [f"-no{key}"]
+        else:
+            commands += [f"-{key}", str(value)]
+    commands += ["-i", node.filename]
+    return commands
+
+
+def get_args_output_node(node: OutputNode, context: DAGContext) -> list[str]:
+    """
+    Generate the FFmpeg command-line arguments for this output file.
+
+    This method creates the command-line arguments needed to specify
+    this output file to FFmpeg, including stream mapping and output-specific
+    options like codecs and formats.
+
+    Args:
+        context: Optional DAG context for resolving stream labels.
+                If not provided, a new context will be built.
+
+    Returns:
+        A list of strings representing FFmpeg command-line arguments
+
+    Example:
+        For an output file "output.mp4" with H.264 video codec:
+        ['-map', '[v0]', '-c:v', 'libx264', 'output.mp4']
+    """
+    # !handle mapping
+    commands = []
+
+    if context:
+        for input in node.inputs:
+            if isinstance(input.node, InputNode):
+                commands += ["-map", get_stream_label(input, context)]
+            else:
+                commands += ["-map", f"[{get_stream_label(input, context)}]"]
+
+    for key, value in node.kwargs.items():
+        if isinstance(value, bool):
+            if value is True:
+                commands += [f"-{key}"]
+            elif value is False:
+                commands += [f"-no{key}"]
+        else:
+            commands += [f"-{key}", str(value)]
+    commands += [node.filename]
+    return commands
+
+
+def get_args_global_node(node: GlobalNode, context: DAGContext) -> list[str]:
+    """
+    Generate the FFmpeg command-line arguments for these global options.
+
+    This method creates the command-line arguments needed to specify
+    global options to FFmpeg, such as -y for overwrite or -loglevel for
+    controlling log output.
+
+    Args:
+        context: Optional DAG context (not used for global options)
+
+    Returns:
+        A list of strings representing FFmpeg command-line arguments
+
+    Example:
+        For global options like overwrite and quiet logging:
+        ['-y', '-loglevel', 'quiet']
+    """
+    commands = []
+    for key, value in node.kwargs.items():
+        if isinstance(value, bool):
+            if value is True:
+                commands += [f"-{key}"]
+            elif value is False:
+                commands += [f"-no{key}"]
+        else:
+            commands += [f"-{key}", str(value)]
+    return commands
+
+
+def get_args(node: Node, context: DAGContext | None = None) -> list[str]:
+    """
+    Get the arguments for a node.
+    """
+
+    context = context or DAGContext.build(node)
+
+    match node:
+        case FilterNode():
+            return get_args_filter_node(node, context)
+        case InputNode():
+            return get_args_input_node(node, context)
+        case OutputNode():
+            return get_args_output_node(node, context)
+        case GlobalNode():
+            return get_args_global_node(node, context)
+        case _:
+            raise FFMpegValueError(f"Unknown node type: {node.__class__.__name__}")
+
+
+def get_node_label(node: Node, context: DAGContext) -> str:
+    """
+    Get the string label for a specific node in the filter graph.
+
+    This method returns the label assigned to the node, which is used in FFmpeg
+    filter graph notation. The label format depends on the node type:
+    - Input nodes: sequential numbers (0, 1, 2...)
+    - Filter nodes: 's' prefix followed by a number (s0, s1, s2...)
+
+    Args:
+        node: The node to get the label for (must be an InputNode or FilterNode)
+
+    Returns:
+        The string label for the node
+
+    Raises:
+        AssertionError: If the node is not an InputNode or FilterNode
+    """
+
+    node_id = context.node_ids[node]
+    match node:
+        case InputNode():
+            return str(node_id)
+        case FilterNode():
+            return f"s{node_id}"
+        case _:
+            return "out"

--- a/src/ffmpeg/compile/tests/test_context.py
+++ b/src/ffmpeg/compile/tests/test_context.py
@@ -5,6 +5,7 @@ from syrupy.assertion import SnapshotAssertion
 from ...base import input
 from ...dag.schema import Node, Stream
 from ...filters import concat
+from ..compile_cli import get_node_label
 from ..context import DAGContext
 
 
@@ -35,7 +36,7 @@ def render(context: DAGContext, obj: Any) -> Any:
         return {render(context, k): render(context, v) for k, v in obj.items()}
 
     if isinstance(obj, Node):
-        return f"Node({obj.repr()}#{context.get_node_label(obj)})"
+        return f"Node({obj.repr()}#{get_node_label(obj, context)})"
 
     if isinstance(obj, Stream):
         return f"Stream({render(context, obj.node)}#{obj.index})"
@@ -60,6 +61,6 @@ def test_context(snapshot: SnapshotAssertion) -> None:
     assert snapshot(name="node_labels") == render(context, context.node_labels)
     assert snapshot(name="node_ids") == render(context, context.node_ids)
 
-    assert context.get_node_label(input1.node) == "0"
+    assert get_node_label(input1.node, context) == "0"
     assert context.get_outgoing_streams(input1.node) == [input1]
     assert context.get_outgoing_nodes(input1) == [(rev.node, 0)]

--- a/src/ffmpeg/dag/schema.py
+++ b/src/ffmpeg/dag/schema.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from functools import cached_property
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from ..common.serialize import Serializable
 from ..utils.forzendict import FrozenDict
 from ..utils.lazy_eval.schema import LazyValue
 from .utils import is_dag
-
-if TYPE_CHECKING:
-    pass
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/ffmpeg/dag/schema.py
+++ b/src/ffmpeg/dag/schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import TYPE_CHECKING, Literal
@@ -11,7 +10,7 @@ from ..utils.lazy_eval.schema import LazyValue
 from .utils import is_dag
 
 if TYPE_CHECKING:
-    from ..compile.context import DAGContext
+    pass
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -77,7 +76,7 @@ class Stream(HashableBaseModel):
 
 
 @dataclass(frozen=True, kw_only=True)
-class Node(HashableBaseModel, ABC):
+class Node(HashableBaseModel):
     """
     A 'Node' represents a single operation in the Directed Acyclic Graph (DAG).
 
@@ -116,18 +115,6 @@ class Node(HashableBaseModel, ABC):
 
         if not is_dag(output):
             raise ValueError(f"Graph is not a DAG: {output}")  # pragma: no cover
-
-    @abstractmethod
-    def get_args(self, context: DAGContext = None) -> list[str]:
-        """
-        Get the arguments of the node.
-
-        Args:
-            context: The DAG context.
-
-        Returns:
-            The arguments of the node.
-        """
 
     def repr(self) -> str:
         """

--- a/src/ffmpeg/dag/tests/__snapshots__/test_nodes.ambr
+++ b/src/ffmpeg/dag/tests/__snapshots__/test_nodes.ambr
@@ -48,7 +48,7 @@
   "GlobalNode(kwargs=FrozenDict({'y': True, 'no': False, 'speed': 1}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='tmp.mp4'), index=None),), filename='temp'), index=None),))"
 # ---
 # name: test_node_prop[global-node][f.repr]
-  '-y -nono -speed 1'
+  "GlobalNode(kwargs=FrozenDict({'y': True, 'no': False, 'speed': 1}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='tmp.mp4'), index=None),), filename='temp'), index=None),))"
 # ---
 # name: test_node_prop[global-node][get_args]
   list([
@@ -76,7 +76,7 @@
   "GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='tmp1.mp4'), index=None),), filename='out1.mp4'), index=None), OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='tmp2.mp4'), index=None),), filename='out2.mp4'), index=None)))"
 # ---
 # name: test_node_prop[merge-output-node][f.repr]
-  ''
+  "GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='tmp1.mp4'), index=None),), filename='out1.mp4'), index=None), OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='tmp2.mp4'), index=None),), filename='out2.mp4'), index=None)))"
 # ---
 # name: test_node_prop[merge-output-node][get_args]
   list([

--- a/src/ffmpeg/dag/tests/test_schema.py
+++ b/src/ffmpeg/dag/tests/test_schema.py
@@ -5,7 +5,6 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
-from ...compile.context import DAGContext
 from ...utils.snapshot import DAGSnapshotExtenstion
 from ..schema import Node, Stream
 
@@ -13,9 +12,6 @@ from ..schema import Node, Stream
 @dataclass(frozen=True, kw_only=True, repr=False)
 class SimpleNode(Node):
     name: str
-
-    def get_args(self, context: DAGContext = None) -> list[str]:
-        return []
 
     def __repr__(self) -> str:
         return self.name


### PR DESCRIPTION
- fix #518

This pull request refactors the FFmpeg DAG compilation logic by centralizing argument generation into dedicated helper functions, improving modularity and maintainability. It also removes redundant methods from node classes and updates tests to reflect these changes.

### Refactoring and Code Simplification:

* Introduced helper functions in `src/ffmpeg/compile/compile_cli.py` (`get_args`, `get_args_input_node`, `get_args_output_node`, `get_args_filter_node`, `get_args_global_node`) to centralize and standardize FFmpeg argument generation for different node types. This replaces the `get_args` methods previously implemented in individual node classes. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L64-R351) [[2]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL170-L227) [[3]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL400-L453) [[4]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL563-L592) [[5]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL645-L685) [[6]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL771-L800)

* Removed the `label` method from `FilterableStream` and replaced its functionality with the new `get_stream_label` function in `src/ffmpeg/compile/compile_cli.py`. This change improves consistency in stream label generation. [[1]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL400-L453) [[2]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L64-R351)

### Dependency Updates:

* Updated imports in `src/ffmpeg/compile/compile_cli.py` and `src/ffmpeg/dag/nodes.py` to align with the new centralized helper functions and removed unused imports. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L12-R17) [[2]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL10-L20)

### Test Adjustments:

* Updated tests in `src/ffmpeg/compile/tests/test_context.py` to use the new `get_node_label` function instead of the removed `get_node_label` method in the `DAGContext` class. [[1]](diffhunk://#diff-9bacf61d5ef1a993ba3afd159d37d39281bd1ddbdc76befba91bd9c3e4e280b7L38-R39) [[2]](diffhunk://#diff-9bacf61d5ef1a993ba3afd159d37d39281bd1ddbdc76befba91bd9c3e4e280b7L63-R64)

### Code Cleanup:

* Removed unused classes, methods, and imports from `src/ffmpeg/dag/schema.py` and `src/ffmpeg/dag/nodes.py`, simplifying the codebase. [[1]](diffhunk://#diff-edd622dd5fd813f4f847dad32d12dbed1cd2b3117827c3a68ff0f0208c20c34eL739-L748) [[2]](diffhunk://#diff-5fd1ebef443a95ada39a1510bb76acc8e217514b469b884867ee7084bcdf8996L3-L15)