### PR TITLE
ref: #512 add compile json to better reuse test case

### DIFF
--- a/src/ffmpeg/compile/compile_json.py
+++ b/src/ffmpeg/compile/compile_json.py
@@ -1,0 +1,38 @@
+from ..common.serialize import dumps, loads
+from ..dag.schema import Stream
+from .validate import validate
+
+
+def compile(stream: Stream, auto_fix: bool = True) -> str:
+    """
+    Compile a stream into a JSON string.
+
+    This function takes a Stream object representing an FFmpeg filter graph
+    and converts it into a JSON string that can be passed to FFmpeg.
+
+    Args:
+        stream: The Stream object to compile into a JSON string
+        auto_fix: Whether to automatically fix issues in the stream
+
+    Returns:
+        A JSON string that can be passed to FFmpeg
+    """
+    stream = validate(stream, auto_fix=auto_fix)
+
+    return dumps(stream)
+
+
+def parse(json: str) -> Stream:
+    """
+    Parse a JSON string into a Stream object.
+
+    This function takes a JSON string that can be passed to FFmpeg
+    and converts it into a Stream object.
+
+    Args:
+        json: The JSON string to parse into a Stream object
+
+    Returns:
+        A Stream object
+    """
+    return loads(json)

--- a/src/ffmpeg/compile/compile_python.py
+++ b/src/ffmpeg/compile/compile_python.py
@@ -191,7 +191,7 @@ def compile_fluent(code: list[str]) -> list[str]:
     return [f"{k.strip()} = {v.strip()}" for k, v in buffer]
 
 
-def compile(stream: Stream, auto_fix: bool = True, fluent: bool = True) -> list[str]:
+def compile(stream: Stream, auto_fix: bool = True, fluent: bool = True) -> str:
     """
     Compile the python code.
 
@@ -295,10 +295,10 @@ def compile(stream: Stream, auto_fix: bool = True, fluent: bool = True) -> list[
     if fluent:
         code = compile_fluent(code)
 
-    return ["import ffmpeg", *code]
+    return "\n".join(["import ffmpeg", *code])
 
 
-def parse(code: list[str]) -> Stream:
+def parse(code: str) -> Stream:
     """
     Parse the python code.
 
@@ -312,7 +312,7 @@ def parse(code: list[str]) -> Stream:
         The parsed stream.
     """
     local_vars: dict[str, Any] = {}
-    exec("\n".join(code), {}, local_vars)
+    exec(code, {}, local_vars)
     result = local_vars["result"]
 
     assert isinstance(result, Stream)

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[amix-stream-2][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[amix-stream-2][compile-json].json
@@ -1,0 +1,188 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "AudioStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 1,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": 0,
+                          "node": {
+                            "__class__": "FilterNode",
+                            "input_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ],
+                            "inputs": [
+                              {
+                                "__class__": "AudioStream",
+                                "index": null,
+                                "node": {
+                                  "__class__": "InputNode",
+                                  "filename": "input1.mp4",
+                                  "inputs": [],
+                                  "kwargs": {}
+                                }
+                              }
+                            ],
+                            "kwargs": {},
+                            "name": "areverse",
+                            "output_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "kwargs": {
+                        "outputs": 2
+                      },
+                      "name": "asplit",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {},
+                "name": "areverse",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "duration": "first",
+            "inputs": 2
+          },
+          "name": "amix",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[amix-stream][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[amix-stream][compile-json].json
@@ -1,0 +1,188 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "AudioStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 1,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": 0,
+                          "node": {
+                            "__class__": "FilterNode",
+                            "input_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ],
+                            "inputs": [
+                              {
+                                "__class__": "AudioStream",
+                                "index": null,
+                                "node": {
+                                  "__class__": "InputNode",
+                                  "filename": "input1.mp4",
+                                  "inputs": [],
+                                  "kwargs": {}
+                                }
+                              }
+                            ],
+                            "kwargs": {},
+                            "name": "areverse",
+                            "output_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "kwargs": {
+                        "outputs": 2
+                      },
+                      "name": "asplit",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {},
+                "name": "areverse",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "duration": "first",
+            "inputs": 2
+          },
+          "name": "amix",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[complex-stream][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[complex-stream][compile-json].json
@@ -1,0 +1,593 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "a": 1,
+            "n": 2,
+            "v": 1
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      },
+      {
+        "__class__": "AudioStream",
+        "index": 1,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "a": 1,
+            "n": 2,
+            "v": 1
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[global-args-2][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[global-args-2][compile-json].json
@@ -1,0 +1,34 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "tmp.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {
+      "dump": true,
+      "hide_banner": true
+    }
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[global-args][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[global-args][compile-json].json
@@ -1,0 +1,33 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "tmp.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {
+      "hide_banner": true
+    }
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[merged-output-1][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[merged-output-1][compile-json].json
@@ -1,0 +1,54 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output1.mp4",
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      },
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output2.mp4",
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input2.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {
+      "dump": true
+    }
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[multi-output-filter][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[multi-output-filter][compile-json].json
@@ -1,0 +1,190 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output1.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        },
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "feedback",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "fontsize": 12,
+                  "text": "Hello World",
+                  "x": 10,
+                  "y": 10
+                },
+                "name": "drawtext",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      },
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output2.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 1,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        },
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "feedback",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "fontsize": 12,
+                  "text": "Hello World",
+                  "x": 10,
+                  "y": 10
+                },
+                "name": "drawtext",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[not-utilize-split][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[not-utilize-split][compile-json].json
@@ -1,0 +1,44 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {},
+          "name": "reverse",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[redundant-split-duplicate][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[redundant-split-duplicate][compile-json].json
@@ -1,0 +1,242 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 3
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 3
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 2,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 3
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "n": 3
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[redundant-split-outputs-1][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[redundant-split-outputs-1][compile-json].json
@@ -1,0 +1,44 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {},
+          "name": "reverse",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[reuse-input][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[reuse-input][compile-json].json
@@ -1,0 +1,60 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {
+            "n": 2
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[reuse-stream][compile-json].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[reuse-stream][compile-json].json
@@ -1,0 +1,164 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "n": 2
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -3,7 +3,7 @@ from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
 from ...dag.schema import Stream
-from ..compile_cli import compile
+from ..compile_cli import compile_as_list
 from .cases import shared_cases
 
 
@@ -11,4 +11,4 @@ from .cases import shared_cases
 def test_compile_cli(snapshot: SnapshotAssertion, graph: Stream) -> None:
     assert snapshot(
         name="compile-cli", extension_class=JSONSnapshotExtension
-    ) == compile(graph)
+    ) == compile_as_list(graph)

--- a/src/ffmpeg/compile/tests/test_compile_json.py
+++ b/src/ffmpeg/compile/tests/test_compile_json.py
@@ -1,22 +1,21 @@
+import json
+
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
+from ...compile.validate import validate
 from ...dag.schema import Stream
-from ..compile_python import compile, parse
-from ..validate import validate
+from ..compile_json import compile, parse
 from .cases import shared_cases
 
 
-@pytest.mark.parametrize("fluent", [True, False])
 @pytest.mark.parametrize("graph", shared_cases)
-def test_compile_python(
-    graph: Stream, fluent: bool, snapshot: SnapshotAssertion
-) -> None:
-    r = compile(graph, fluent=fluent)
+def test_compile_json(graph: Stream, snapshot: SnapshotAssertion) -> None:
+    r = compile(graph)
     assert snapshot(
-        name="compile-python", extension_class=JSONSnapshotExtension
-    ) == r.split("\n")
+        name="compile-json", extension_class=JSONSnapshotExtension
+    ) == json.loads(r)
 
     assert parse(r) == validate(graph, auto_fix=True), (
         "parse result should be equal to the original graph"

--- a/src/ffmpeg/dag/global_runnable/runnable.py
+++ b/src/ffmpeg/dag/global_runnable/runnable.py
@@ -81,7 +81,7 @@ class GlobalRunable(GlobalArgs):
     def compile(
         self,
         cmd: str | list[str] = "ffmpeg",
-        overwrite_output: bool = None,
+        overwrite_output: bool | None = None,
         auto_fix: bool = True,
     ) -> list[str]:
         """
@@ -111,7 +111,7 @@ class GlobalRunable(GlobalArgs):
             # Result: ['ffmpeg', '-i', 'input.mp4', 'output.mp4']
             ```
         """
-        from ...compile.compile_cli import compile
+        from ...compile.compile_cli import compile_as_list
 
         if isinstance(cmd, str):
             cmd = [cmd]
@@ -121,12 +121,12 @@ class GlobalRunable(GlobalArgs):
         elif overwrite_output is False:
             return self.global_args(n=True).compile(cmd, auto_fix=auto_fix)
 
-        return cmd + compile(self._global_node().stream(), auto_fix=auto_fix)
+        return cmd + compile_as_list(self._global_node().stream(), auto_fix=auto_fix)
 
     def compile_line(
         self,
         cmd: str | list[str] = "ffmpeg",
-        overwrite_output: bool = None,
+        overwrite_output: bool | None = None,
         auto_fix: bool = True,
     ) -> str:
         """
@@ -165,7 +165,7 @@ class GlobalRunable(GlobalArgs):
         pipe_stdout: bool = False,
         pipe_stderr: bool = False,
         quiet: bool = False,
-        overwrite_output: bool = None,
+        overwrite_output: bool | None = None,
         auto_fix: bool = True,
     ) -> subprocess.Popen[bytes]:
         """
@@ -222,7 +222,7 @@ class GlobalRunable(GlobalArgs):
         capture_stderr: bool = False,
         input: bytes | None = None,
         quiet: bool = False,
-        overwrite_output: bool = None,
+        overwrite_output: bool | None = None,
         auto_fix: bool = True,
     ) -> tuple[bytes, bytes]:
         """


### PR DESCRIPTION
This pull request introduces enhancements and refactoring to the FFmpeg compilation utilities, including improvements to the `compile_cli.py` module, the addition of JSON-based compilation in `compile_json.py`, and updates to Python-based compilation in `compile_python.py`. The changes focus on better documentation, improved functionality, and new features for handling FFmpeg command-line generation and serialization.

### Enhancements to `compile_cli.py`:

* **Improved Documentation**: Enhanced docstrings for several functions to provide detailed explanations of their purpose, arguments, and return values. Examples include `compile`, `get_args_filter_node`, `get_args_input_node`, and `get_args_output_node` functions. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R25-R47) [[2]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R140) [[3]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R189-R194) [[4]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R243-R248) [[5]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L240-R281)
* **Error Handling**: Added `FFMpegValueError` as a potential raised exception for invalid configurations in the `compile` function.
* **New Functionality**: Introduced a `compile_as_list` function to generate FFmpeg arguments as a list, while the `compile` function now returns a command-line string.

### Addition of JSON-based Compilation (`compile_json.py`):

* **New Module**: Added a new module for compiling FFmpeg streams into JSON strings and parsing JSON back into stream objects. This includes `compile` and `parse` functions for handling JSON serialization and deserialization.

### Updates to Python-based Compilation (`compile_python.py`):

* **String Output**: Modified the `compile` function to return a single Python code string instead of a list of strings. [[1]](diffhunk://#diff-659ecc661151a1e4ce89e273903a368b301a536eac251e0d27d063900e5ae60bL194-R194) [[2]](diffhunk://#diff-659ecc661151a1e4ce89e273903a368b301a536eac251e0d27d063900e5ae60bL298-R301)
* **Updated Parsing**: Adjusted the `parse` function to accept a single string of Python code instead of a list of strings.

### Test Snapshots:

* **New Snapshot**: Added a snapshot for testing JSON-based compilation, ensuring the correctness of the serialization process. ([src/ffmpeg/compile/tests/__snapshots__/test_compile_json/test_compile_json[amix-stream-2][compile-json].jsonR1-R188](diffhunk://#diff-4103d2451ff6acfcd1c890dc388e6185353e9fc1323475166e8c84faf587d56fR1-R188))