### PR TITLE
Fix #512 add dag ts

### DIFF
--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[amix-stream-2][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[amix-stream-2][compile-json].json
@@ -1,0 +1,188 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "AudioStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 1,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": 0,
+                          "node": {
+                            "__class__": "FilterNode",
+                            "input_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ],
+                            "inputs": [
+                              {
+                                "__class__": "AudioStream",
+                                "index": null,
+                                "node": {
+                                  "__class__": "InputNode",
+                                  "filename": "input1.mp4",
+                                  "inputs": [],
+                                  "kwargs": {}
+                                }
+                              }
+                            ],
+                            "kwargs": {},
+                            "name": "areverse",
+                            "output_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "kwargs": {
+                        "outputs": 2
+                      },
+                      "name": "asplit",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {},
+                "name": "areverse",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "duration": "first",
+            "inputs": 2
+          },
+          "name": "amix",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[amix-stream][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[amix-stream][compile-json].json
@@ -1,0 +1,188 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "AudioStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 1,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": 0,
+                          "node": {
+                            "__class__": "FilterNode",
+                            "input_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ],
+                            "inputs": [
+                              {
+                                "__class__": "AudioStream",
+                                "index": null,
+                                "node": {
+                                  "__class__": "InputNode",
+                                  "filename": "input1.mp4",
+                                  "inputs": [],
+                                  "kwargs": {}
+                                }
+                              }
+                            ],
+                            "kwargs": {},
+                            "name": "areverse",
+                            "output_typings": [
+                              {
+                                "__class__": "StreamType",
+                                "value": "audio"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "kwargs": {
+                        "outputs": 2
+                      },
+                      "name": "asplit",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {},
+                "name": "areverse",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "duration": "first",
+            "inputs": 2
+          },
+          "name": "amix",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[complex-stream][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[complex-stream][compile-json].json
@@ -1,0 +1,593 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "a": 1,
+            "n": 2,
+            "v": 1
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      },
+      {
+        "__class__": "AudioStream",
+        "index": 1,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "VideoStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "AudioStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "AudioStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AudioStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "areverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "audio"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "asplit",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "audio"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "a": 1,
+            "n": 2,
+            "v": 1
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "audio"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[global-args-2][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[global-args-2][compile-json].json
@@ -1,0 +1,34 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "tmp.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {
+      "dump": true,
+      "hide_banner": true
+    }
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[global-args][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[global-args][compile-json].json
@@ -1,0 +1,33 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "tmp.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {
+      "hide_banner": true
+    }
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[merged-output-1][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[merged-output-1][compile-json].json
@@ -1,0 +1,54 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output1.mp4",
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      },
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output2.mp4",
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input2.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {
+      "dump": true
+    }
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[multi-output-filter][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[multi-output-filter][compile-json].json
@@ -1,0 +1,190 @@
+{
+  "__class__": "GlobalStream",
+  "index": null,
+  "node": {
+    "__class__": "GlobalNode",
+    "inputs": [
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output1.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        },
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "feedback",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "fontsize": 12,
+                  "text": "Hello World",
+                  "x": 10,
+                  "y": 10
+                },
+                "name": "drawtext",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      },
+      {
+        "__class__": "OutputStream",
+        "index": null,
+        "node": {
+          "__class__": "OutputNode",
+          "filename": "output2.mp4",
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 1,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        },
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input2.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "feedback",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        },
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "fontsize": 12,
+                  "text": "Hello World",
+                  "x": 10,
+                  "y": 10
+                },
+                "name": "drawtext",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {}
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[not-utilize-split][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[not-utilize-split][compile-json].json
@@ -1,0 +1,44 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {},
+          "name": "reverse",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[redundant-split-duplicate][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[redundant-split-duplicate][compile-json].json
@@ -1,0 +1,242 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 3
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 3
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 2,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input1.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 3
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "n": 3
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[redundant-split-outputs-1][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[redundant-split-outputs-1][compile-json].json
@@ -1,0 +1,44 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "AVStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input1.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {},
+          "name": "reverse",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[reuse-input][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[reuse-input][compile-json].json
@@ -1,0 +1,60 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": null,
+              "node": {
+                "__class__": "InputNode",
+                "filename": "input.mp4",
+                "inputs": [],
+                "kwargs": {}
+              }
+            }
+          ],
+          "kwargs": {
+            "n": 2
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[reuse-stream][compile-json].json
+++ b/ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[reuse-stream][compile-json].json
@@ -1,0 +1,164 @@
+{
+  "__class__": "OutputStream",
+  "index": null,
+  "node": {
+    "__class__": "OutputNode",
+    "filename": "tmp.mp4",
+    "inputs": [
+      {
+        "__class__": "VideoStream",
+        "index": 0,
+        "node": {
+          "__class__": "FilterNode",
+          "input_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            },
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ],
+          "inputs": [
+            {
+              "__class__": "VideoStream",
+              "index": 0,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            },
+            {
+              "__class__": "VideoStream",
+              "index": 1,
+              "node": {
+                "__class__": "FilterNode",
+                "input_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ],
+                "inputs": [
+                  {
+                    "__class__": "VideoStream",
+                    "index": 0,
+                    "node": {
+                      "__class__": "FilterNode",
+                      "input_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ],
+                      "inputs": [
+                        {
+                          "__class__": "AVStream",
+                          "index": null,
+                          "node": {
+                            "__class__": "InputNode",
+                            "filename": "input.mp4",
+                            "inputs": [],
+                            "kwargs": {}
+                          }
+                        }
+                      ],
+                      "kwargs": {},
+                      "name": "reverse",
+                      "output_typings": [
+                        {
+                          "__class__": "StreamType",
+                          "value": "video"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "kwargs": {
+                  "outputs": 2
+                },
+                "name": "split",
+                "output_typings": [
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  },
+                  {
+                    "__class__": "StreamType",
+                    "value": "video"
+                  }
+                ]
+              }
+            }
+          ],
+          "kwargs": {
+            "n": 2
+          },
+          "name": "concat",
+          "output_typings": [
+            {
+              "__class__": "StreamType",
+              "value": "video"
+            }
+          ]
+        }
+      }
+    ],
+    "kwargs": {}
+  }
+}

--- a/ffmpeg-flow-editor/src/types/__tests__/dag.test.ts
+++ b/ffmpeg-flow-editor/src/types/__tests__/dag.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { loads, clearClassRegistry } from '../../utils/serialize';
+import { loads, clearClassRegistry, registerClasses } from '../../utils/serialize';
 import { Serializable } from '../../utils/serialize';
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
@@ -18,47 +18,25 @@ import {
   OutputStream,
   GlobalStream,
 } from '../dag';
-import { FFmpegFilter, FFmpegIOType } from '../ffmpeg';
 
-// Clear and re-register all classes before tests
+// Clear and register classes before tests
 beforeAll(() => {
   clearClassRegistry();
-  // Create instances to trigger registration
-  new StreamType('audio');
-  new StreamType('video');
-  const testFilter: FFmpegFilter = {
-    __class__: 'FFMpegFilter',
-    id: 'test',
-    name: 'test',
-    description: 'test',
-    ref: 'test',
-    is_support_slice_threading: false,
-    is_support_timeline: false,
-    is_support_framesync: false,
-    is_support_command: false,
-    is_filter_sink: false,
-    is_filter_source: false,
-    is_dynamic_input: false,
-    is_dynamic_output: false,
-    stream_typings_input: [],
-    stream_typings_output: [],
-    formula_typings_input: null,
-    formula_typings_output: null,
-    pre: [],
-    options: [],
-  };
-  const inputNode = new InputNode('test');
-  const outputNode = new OutputNode('test', []);
-  new FilterNode('test', [], [StreamType.audio], [StreamType.audio], testFilter);
-  new InputNode('test');
-  new OutputNode('test', []);
-  new GlobalNode([]);
-  new FilterableStream(inputNode, 0);
-  new VideoStream(inputNode, 0);
-  new AudioStream(inputNode, 0);
-  new AVStream(inputNode, 0);
-  new OutputStream(outputNode, 0);
-  new GlobalStream(new GlobalNode([]), 0);
+
+  // Register all classes explicitly
+  registerClasses({
+    StreamType,
+    FilterNode,
+    InputNode,
+    OutputNode,
+    GlobalNode,
+    FilterableStream,
+    VideoStream,
+    AudioStream,
+    AVStream,
+    OutputStream,
+    GlobalStream,
+  });
 });
 
 // Get all JSON files from the test data directory

--- a/ffmpeg-flow-editor/src/types/__tests__/dag.test.ts
+++ b/ffmpeg-flow-editor/src/types/__tests__/dag.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { loads, clearClassRegistry } from '../../utils/serialize';
+import { Serializable } from '../../utils/serialize';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+// Import all DAG classes to register them
+import {
+  StreamType,
+  FilterNode,
+  InputNode,
+  OutputNode,
+  GlobalNode,
+  FilterableStream,
+  VideoStream,
+  AudioStream,
+  AVStream,
+  OutputStream,
+  GlobalStream,
+} from '../dag';
+import { FFmpegFilter, FFmpegIOType } from '../ffmpeg';
+
+// Clear and re-register all classes before tests
+beforeAll(() => {
+  clearClassRegistry();
+  // Create instances to trigger registration
+  new StreamType('audio');
+  new StreamType('video');
+  const testFilter: FFmpegFilter = {
+    __class__: 'FFMpegFilter',
+    id: 'test',
+    name: 'test',
+    description: 'test',
+    ref: 'test',
+    is_support_slice_threading: false,
+    is_support_timeline: false,
+    is_support_framesync: false,
+    is_support_command: false,
+    is_filter_sink: false,
+    is_filter_source: false,
+    is_dynamic_input: false,
+    is_dynamic_output: false,
+    stream_typings_input: [],
+    stream_typings_output: [],
+    formula_typings_input: null,
+    formula_typings_output: null,
+    pre: [],
+    options: [],
+  };
+  const inputNode = new InputNode('test');
+  const outputNode = new OutputNode('test', []);
+  new FilterNode('test', [], [StreamType.audio], [StreamType.audio], testFilter);
+  new InputNode('test');
+  new OutputNode('test', []);
+  new GlobalNode([]);
+  new FilterableStream(inputNode, 0);
+  new VideoStream(inputNode, 0);
+  new AudioStream(inputNode, 0);
+  new AVStream(inputNode, 0);
+  new OutputStream(outputNode, 0);
+  new GlobalStream(new GlobalNode([]), 0);
+});
+
+// Get all JSON files from the test data directory
+const testDataDir = join(__dirname, '__testdata__');
+const testFiles = readdirSync(testDataDir)
+  .filter((file) => file.endsWith('.json'))
+  .map((file) => ({
+    name: file.replace('.json', ''),
+    data: JSON.parse(readFileSync(join(testDataDir, file), 'utf-8')),
+  }));
+
+describe('DAG Serialization', () => {
+  it.each(testFiles)('should handle $name case', ({ data }) => {
+    // Convert to string for deserialization
+    const jsonString = JSON.stringify(data);
+
+    // Deserialize
+    const deserialized = loads(jsonString);
+
+    // Verify it's a Serializable instance
+    expect(deserialized).toBeInstanceOf(Serializable);
+
+    // Serialize back using toJSON
+    const serialized = JSON.stringify((deserialized as Serializable).toJSON());
+
+    // Parse both for comparison
+    const original = JSON.parse(jsonString);
+    const roundTrip = JSON.parse(serialized);
+
+    // Compare the structures
+    expect(roundTrip).toEqual(original);
+  });
+});

--- a/ffmpeg-flow-editor/src/types/dag.ts
+++ b/ffmpeg-flow-editor/src/types/dag.ts
@@ -1,0 +1,118 @@
+import { FFmpegFilter } from './ffmpeg';
+import { Serializable, serializable } from '../utils/serialize';
+
+// Core types
+export enum StreamType {
+  audio = 'audio',
+  video = 'video',
+}
+
+// Base interfaces
+export interface Node {
+  kwargs: Record<string, string | number | boolean>;
+  inputs: Stream[];
+}
+
+export interface Stream {
+  node: Node;
+  index: number | null;
+}
+
+// Node types
+@serializable
+export class FilterNode extends Serializable implements Node {
+  constructor(
+    public name: string,
+    public inputs: FilterableStream[],
+    public input_typings: StreamType[],
+    public output_typings: StreamType[],
+    public filter: FFmpegFilter,
+    public kwargs: Record<string, string | number | boolean> = {}
+  ) {
+    super();
+  }
+}
+
+@serializable
+export class InputNode extends Serializable implements Node {
+  constructor(
+    public filename: string,
+    public inputs: [] = [],
+    public kwargs: Record<string, string | number | boolean> = {}
+  ) {
+    super();
+  }
+}
+
+@serializable
+export class OutputNode extends Serializable implements Node {
+  constructor(
+    public filename: string,
+    public inputs: FilterableStream[],
+    public kwargs: Record<string, string | number | boolean> = {}
+  ) {
+    super();
+  }
+}
+
+@serializable
+export class GlobalNode extends Serializable implements Node {
+  constructor(
+    public inputs: OutputStream[],
+    public kwargs: Record<string, string | number | boolean> = {}
+  ) {
+    super();
+  }
+}
+
+// Stream types
+@serializable
+export class FilterableStream extends Serializable implements Stream {
+  constructor(
+    public node: FilterNode | InputNode,
+    public index: number | null = null
+  ) {
+    super();
+  }
+}
+
+@serializable
+export class VideoStream extends FilterableStream {
+  constructor(node: FilterNode | InputNode, index: number | null = null) {
+    super(node, index);
+  }
+}
+
+@serializable
+export class AudioStream extends FilterableStream {
+  constructor(node: FilterNode | InputNode, index: number | null = null) {
+    super(node, index);
+  }
+}
+
+@serializable
+export class AVStream extends FilterableStream {
+  constructor(node: FilterNode | InputNode, index: number | null = null) {
+    super(node, index);
+  }
+}
+
+@serializable
+export class OutputStream extends Serializable implements Stream {
+  constructor(
+    public node: OutputNode,
+    public index: number | null = null
+  ) {
+    super();
+  }
+}
+
+@serializable
+export class GlobalStream extends Serializable implements Stream {
+  constructor(
+    public node: GlobalNode,
+    public index: number | null = null
+  ) {
+    super();
+  }
+}

--- a/ffmpeg-flow-editor/src/types/dag.ts
+++ b/ffmpeg-flow-editor/src/types/dag.ts
@@ -1,10 +1,11 @@
 import { FFmpegFilter } from './ffmpeg';
-import { Serializable, serializable } from '../utils/serialize';
+import { Serializable } from '../utils/serialize';
 
 // Core types
-export enum StreamType {
-  audio = 'audio',
-  video = 'video',
+export class StreamType extends Serializable {
+  constructor(public value: string) {
+    super();
+  }
 }
 
 // Base interfaces
@@ -19,7 +20,6 @@ export interface Stream {
 }
 
 // Node types
-@serializable
 export class FilterNode extends Serializable implements Node {
   constructor(
     public name: string,
@@ -33,7 +33,6 @@ export class FilterNode extends Serializable implements Node {
   }
 }
 
-@serializable
 export class InputNode extends Serializable implements Node {
   constructor(
     public filename: string,
@@ -44,7 +43,6 @@ export class InputNode extends Serializable implements Node {
   }
 }
 
-@serializable
 export class OutputNode extends Serializable implements Node {
   constructor(
     public filename: string,
@@ -55,7 +53,6 @@ export class OutputNode extends Serializable implements Node {
   }
 }
 
-@serializable
 export class GlobalNode extends Serializable implements Node {
   constructor(
     public inputs: OutputStream[],
@@ -66,7 +63,6 @@ export class GlobalNode extends Serializable implements Node {
 }
 
 // Stream types
-@serializable
 export class FilterableStream extends Serializable implements Stream {
   constructor(
     public node: FilterNode | InputNode,
@@ -76,28 +72,24 @@ export class FilterableStream extends Serializable implements Stream {
   }
 }
 
-@serializable
 export class VideoStream extends FilterableStream {
   constructor(node: FilterNode | InputNode, index: number | null = null) {
     super(node, index);
   }
 }
 
-@serializable
 export class AudioStream extends FilterableStream {
   constructor(node: FilterNode | InputNode, index: number | null = null) {
     super(node, index);
   }
 }
 
-@serializable
 export class AVStream extends FilterableStream {
   constructor(node: FilterNode | InputNode, index: number | null = null) {
     super(node, index);
   }
 }
 
-@serializable
 export class OutputStream extends Serializable implements Stream {
   constructor(
     public node: OutputNode,
@@ -107,7 +99,6 @@ export class OutputStream extends Serializable implements Stream {
   }
 }
 
-@serializable
 export class GlobalStream extends Serializable implements Stream {
   constructor(
     public node: GlobalNode,

--- a/ffmpeg-flow-editor/src/types/ffmpeg.ts
+++ b/ffmpeg-flow-editor/src/types/ffmpeg.ts
@@ -1,4 +1,5 @@
 import filtersConfig from '../config/filters.json';
+import { StreamType } from './dag';
 
 export interface FFmpegFilter {
   __class__: 'FFMpegFilter';
@@ -27,7 +28,7 @@ export interface FFmpegIOType {
   name: string;
   type: {
     __class__: 'StreamType';
-    value: string;
+    value: StreamType;
   };
 }
 

--- a/ffmpeg-flow-editor/src/utils/serialize.ts
+++ b/ffmpeg-flow-editor/src/utils/serialize.ts
@@ -1,0 +1,106 @@
+// Class registry for serialization
+const classRegistry = new Map<string, new (...args: any[]) => any>();
+
+// Base class for serializable objects
+export class Serializable {
+  toJSON(): any {
+    const obj: any = {};
+    for (const key in this) {
+      if (Object.prototype.hasOwnProperty.call(this, key)) {
+        obj[key] = this[key];
+      }
+    }
+    obj.__class__ = this.constructor.name;
+    return obj;
+  }
+}
+
+// Register a class for serialization
+export function registerClass(name: string, constructor: new (...args: any[]) => any) {
+  console.log(`Registering class: ${name}`);
+  classRegistry.set(name, constructor);
+}
+
+// Register multiple classes at once
+export function registerClasses(classes: Record<string, new (...args: any[]) => any>) {
+  console.log('Registering classes:', Object.keys(classes));
+  for (const [name, constructor] of Object.entries(classes)) {
+    classRegistry.set(name, constructor);
+  }
+}
+
+// Clear the class registry
+export function clearClassRegistry() {
+  console.log('Clearing class registry');
+  classRegistry.clear();
+}
+
+// Get registered class names
+export function getRegisteredClassNames(): string[] {
+  return Array.from(classRegistry.keys());
+}
+
+// Serialize an object to JSON string
+export function dumps(obj: any): string {
+  return JSON.stringify(obj);
+}
+
+// Deserialize a JSON string to an object
+export function loads(json: string): any {
+  const obj = JSON.parse(json);
+  return deserializeObject(obj);
+}
+
+// Helper function to deserialize an object
+function deserializeObject(obj: any): any {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  // Handle arrays
+  if (Array.isArray(obj)) {
+    return obj.map(deserializeObject);
+  }
+
+  // Handle special types
+  if (obj instanceof Date) {
+    return new Date(obj);
+  }
+
+  if (obj instanceof Map) {
+    return new Map(Array.from(obj.entries()).map(([k, v]) => [k, deserializeObject(v)]));
+  }
+
+  if (obj instanceof Set) {
+    return new Set(Array.from(obj).map(deserializeObject));
+  }
+
+  // Handle class instances
+  if (obj.__class__) {
+    console.log('Looking for class:', obj.__class__);
+    console.log('Registered classes:', getRegisteredClassNames());
+    const Constructor = classRegistry.get(obj.__class__);
+    if (!Constructor) {
+      throw new Error(`Class ${obj.__class__} not registered`);
+    }
+
+    // Create a new instance without calling constructor
+    const instance = Object.create(Constructor.prototype);
+
+    // Deserialize all properties
+    for (const key in obj) {
+      if (key !== '__class__') {
+        instance[key] = deserializeObject(obj[key]);
+      }
+    }
+
+    return instance;
+  }
+
+  // Handle plain objects
+  const result: any = {};
+  for (const key in obj) {
+    result[key] = deserializeObject(obj[key]);
+  }
+  return result;
+}

--- a/ffmpeg-flow-editor/src/utils/serialize.ts
+++ b/ffmpeg-flow-editor/src/utils/serialize.ts
@@ -15,12 +15,6 @@ export class Serializable {
   }
 }
 
-// Register a class for serialization
-export function registerClass(name: string, constructor: new (...args: any[]) => any) {
-  console.log(`Registering class: ${name}`);
-  classRegistry.set(name, constructor);
-}
-
 // Register multiple classes at once
 export function registerClasses(classes: Record<string, new (...args: any[]) => any>) {
   console.log('Registering classes:', Object.keys(classes));


### PR DESCRIPTION
This pull request adds several new test data files for the `ffmpeg-flow-editor` project, focusing on different configurations of input and output streams, filters, and global arguments. These changes aim to enhance the test coverage and validate various scenarios in the JSON compilation process.

### Test Data Additions

#### Audio Stream Scenarios:
* Added `test_compile_json[amix-stream-2][compile-json].json` and `test_compile_json[amix-stream][compile-json].json` to test the `amix` filter with multiple audio streams, including intermediate filters like `areverse` and `asplit`. These tests validate the handling of complex audio stream setups. ([ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[amix-stream-2][compile-json].jsonR1-R188](diffhunk://#diff-89d6330b6ee3df4102bb48fb5e3213ffffaa0904e7e51a9b7f19a243845c2947R1-R188), [ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[amix-stream][compile-json].jsonR1-R188](diffhunk://#diff-f1fe88048f43a4aa9d2788cc1f32206eca2e92cc51464dcafb215c7d2700c16dR1-R188))

#### Global Argument Scenarios:
* Added `test_compile_json[global-args-2][compile-json].json` and `test_compile_json[global-args][compile-json].json` to test global arguments like `hide_banner` and `dump`. These tests ensure that global options are correctly applied to the compilation process. ([ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[global-args-2][compile-json].jsonR1-R34](diffhunk://#diff-ced4d10b635174e5fb9c7f9f5da5479ed9ed38bdf6733fbbd7742ec9e6fee861R1-R34), [ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[global-args][compile-json].jsonR1-R33](diffhunk://#diff-fb0bf2e295e9e311fb65e4ebba5a46f7f1c429bb3aedd9f2a040bb759bdcd750R1-R33))

#### Multi-Output Scenarios:
* Added `test_compile_json[merged-output-1][compile-json].json` and `test_compile_json[multi-output-filter][compile-json].json` to test scenarios with multiple output streams, including filters like `feedback` and `drawtext`. These tests validate the correct handling of multi-output configurations and filter chaining. ([ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[merged-output-1][compile-json].jsonR1-R54](diffhunk://#diff-cce69b78b22fb96bf6593c3981b1889ec49d23fc16693c6f45f0075622716b8cR1-R54), [ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[multi-output-filter][compile-json].jsonR1-R190](diffhunk://#diff-20704866d91c3a194ee8a5cd11bdc80c96f68cf02cef125a8fd8cd94a1c01ce6R1-R190))

#### Simple Video Filter Scenario:
* Added `test_compile_json[not-utilize-split][compile-json].json` to test a simple video filter (`reverse`) applied to a single input stream. This ensures basic filter functionality is verified. ([ffmpeg-flow-editor/src/types/__tests__/__testdata__/test_compile_json[not-utilize-split][compile-json].jsonR1-R44](diffhunk://#diff-3dde4462500f0533d69991c3a2bd65f552b2567e7baaaa779425a3666701a4afR1-R44))