### PR TITLE
Fix 494 io options

### DIFF
--- a/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
+++ b/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
@@ -27,8 +27,8 @@ import { NodeData } from '../types/node';
 const nodeTypes = {
   filter: FilterNode,
   global: GlobalNode,
-  input: InputNode,
-  output: OutputNode,
+  input_: InputNode,
+  output_: OutputNode,
 } as const;
 
 // Helper function to determine edge type from stream
@@ -159,9 +159,18 @@ const createNode = (
 
   const nodeId = nodeMappingManager.addNodeToMapping(mappingData);
 
+  // if nodeType is input or output add a `_` to the end of the nodeType
+  let nodeType_: string;
+  if (nodeType === 'input' || nodeType === 'output') {
+    nodeType_ = nodeType + '_';
+  }
+  else {
+    nodeType_ = nodeType;
+  }
+
   return {
     id: nodeId,
-    type: nodeType,
+    type: nodeType_,
     position: position || defaultPosition,
     data: {
       label: label,

--- a/ffmpeg-flow-editor/src/components/GlobalNode.tsx
+++ b/ffmpeg-flow-editor/src/components/GlobalNode.tsx
@@ -1,31 +1,113 @@
-import { memo } from 'react';
+import { memo, useState, useEffect } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Paper, Typography, useTheme } from '@mui/material';
+import { Paper, Typography, TextField, Box, Tooltip, useTheme } from '@mui/material';
 import { EDGE_COLORS } from '../types/edge';
 import { NodeData } from '../types/node';
-function GlobalNode({ data }: NodeProps<NodeData>) {
+import options from '../config/options.json';
+
+// Input and output flags
+const INPUT_FLAG = 1 << 11;
+const OUTPUT_FLAG = 1 << 12;
+
+// Global options are those which are neither input nor output options
+const globalOptions = options.filter((option) => 
+  (option.flags & INPUT_FLAG) === 0 && 
+  (option.flags & OUTPUT_FLAG) === 0 &&
+  option.type !== "OPT_TYPE_FUNC" // Skip function type options that can't be set through text input
+);
+
+function GlobalNode({ data, id }: NodeProps<NodeData>) {
   const theme = useTheme();
+  const [parameters, setParameters] = useState<Record<string, string>>(data.parameters || {});
+
+  // Update local state when data changes
+  useEffect(() => {
+    setParameters(data.parameters || {});
+  }, [data.parameters]);
+
+  const handleParameterChange = (paramName: string, value: string) => {
+    const newParameters = {
+      ...parameters,
+      [paramName]: value,
+    };
+    setParameters(newParameters);
+
+    // Update the node data
+    const event = new CustomEvent('updateNodeData', {
+      detail: {
+        id,
+        data: {
+          ...data,
+          parameters: newParameters,
+        },
+      },
+    });
+    window.dispatchEvent(event);
+  };
+
+  // Get command line representation
+  const getCommandString = () => {
+    const paramString = Object.entries(parameters)
+      .filter(([, value]) => value !== '')
+      .map(([key, value]) => `-${key} ${value}`)
+      .join(' ');
+
+    return paramString;
+  };
 
   return (
     <Paper 
       elevation={3} 
       sx={{ 
-        width: '100%',
-        height: '100%',
-        boxSizing: 'border-box',
-        padding: 2, 
+        padding: 2,
+        minWidth: 200,
         backgroundColor: '#f3e5f5',
         border: `2px solid #9c27b0`,
         color: theme.palette.text.primary,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'stretch',
       }}
     >
       <Typography variant="h6" gutterBottom>
         {data.label}
       </Typography>
+
+      <Box sx={{ mt: 1 }}>
+        {globalOptions.map((option) => (
+          <Box key={option.name} sx={{ mt: 1 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label={option.name}
+              placeholder={option.argname || ''}
+              value={parameters[option.name] || ''}
+              onChange={(e) => handleParameterChange(option.name, e.target.value)}
+              variant="outlined"
+              margin="dense"
+              helperText={option.help}
+              InputProps={{
+                sx: {
+                  '& input::placeholder': {
+                    color: 'text.disabled',
+                    opacity: 0.7,
+                  },
+                },
+              }}
+            />
+          </Box>
+        ))}
+        
+        <Tooltip title={getCommandString()}>
+          <Typography
+            variant="caption"
+            sx={{
+              mt: 1,
+              display: 'block',
+              color: 'text.secondary',
+            }}
+          >
+            {getCommandString()}
+          </Typography>
+        </Tooltip>
+      </Box>
 
       {/* Input handles */}
       {data.handles.inputs.map((handle, index) => (

--- a/ffmpeg-flow-editor/src/components/InputNode.tsx
+++ b/ffmpeg-flow-editor/src/components/InputNode.tsx
@@ -1,42 +1,149 @@
-import { memo, useState } from 'react';
+import { memo, useState, useEffect } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Paper, Typography, TextField, useTheme } from '@mui/material';
+import { Paper, Typography, TextField, Box, Tooltip, useTheme } from '@mui/material';
 import { EDGE_COLORS } from '../types/edge';
 import { NodeData } from '../types/node';
+import options from '../config/options.json';
 
-function InputNode({ data }: NodeProps<NodeData>) {
+// Input options are those with flags & (1 << 11)
+const INPUT_FLAG = 1 << 11;
+const inputOptions = options.filter((option) => 
+  (option.flags & INPUT_FLAG) !== 0 && 
+  option.type !== "OPT_TYPE_FUNC" // Skip function type options that can't be set through text input
+);
+
+function InputNode({ data, id }: NodeProps<NodeData>) {
   const theme = useTheme();
   const [filename, setFilename] = useState<string>(data.filename || '');
+  const [parameters, setParameters] = useState<Record<string, string>>(data.parameters || {});
+
+  // Update local state when data changes
+  useEffect(() => {
+    setFilename(data.filename || '');
+    setParameters(data.parameters || {});
+  }, [data.filename, data.parameters]);
+
+  const handleParameterChange = (paramName: string, value: string) => {
+    const newParameters = {
+      ...parameters,
+      [paramName]: value,
+    };
+    setParameters(newParameters);
+
+    // Update the node data
+    const event = new CustomEvent('updateNodeData', {
+      detail: {
+        id,
+        data: {
+          ...data,
+          filename,
+          parameters: newParameters,
+        },
+      },
+    });
+    window.dispatchEvent(event);
+  };
+
+  const handleFilenameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newFilename = e.target.value;
+    setFilename(newFilename);
+    
+    // Update the node data
+    const event = new CustomEvent('updateNodeData', {
+      detail: {
+        id,
+        data: {
+          ...data,
+          filename: newFilename,
+          parameters,
+        },
+      },
+    });
+    window.dispatchEvent(event);
+  };
+
+  // Get command line representation
+  const getCommandString = () => {
+    const paramString = Object.entries(parameters)
+      .filter(([, value]) => value !== '')
+      .map(([key, value]) => `-${key} ${value}`)
+      .join(' ');
+
+    return `-i ${filename} ${paramString}`;
+  };
 
   return (
     <Paper 
       elevation={3} 
       sx={{ 
-        width: '100%',
-        height: '100%',
-        boxSizing: 'border-box',
-        padding: 2, 
+        padding: 2,
+        minWidth: 200,
         backgroundColor: '#e8f5e9',
         border: '2px solid #4caf50',
         color: theme.palette.text.primary,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'stretch',
       }}
     >
       <Typography variant="h6" gutterBottom>
         {data.label}
       </Typography>
       
-      <TextField
-        label="Filename"
-        value={filename}
-        onChange={(e) => setFilename(e.target.value)}
-        fullWidth
-        margin="normal"
-        size="small"
-      />
+      <Box sx={{ mt: 1 }}>
+        <TextField
+          fullWidth
+          size="small"
+          label="Filename"
+          value={filename}
+          onChange={handleFilenameChange}
+          variant="outlined"
+          margin="dense"
+          helperText="Input file path"
+          InputProps={{
+            sx: {
+              '& input::placeholder': {
+                color: 'text.disabled',
+                opacity: 1,
+              },
+            },
+          }}
+        />
+
+        {inputOptions.map((option) => (
+          <Box key={option.name} sx={{ mt: 1 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label={option.name}
+              placeholder={option.argname || ''}
+              value={parameters[option.name] || ''}
+              onChange={(e) => handleParameterChange(option.name, e.target.value)}
+              variant="outlined"
+              margin="dense"
+              helperText={option.help}
+              InputProps={{
+                sx: {
+                  '& input::placeholder': {
+                    color: 'text.disabled',
+                    opacity: 0.7,
+                  },
+                },
+              }}
+            />
+          </Box>
+        ))}
+
+        <Tooltip title={getCommandString()}>
+          <Typography
+            variant="caption"
+            sx={{
+              mt: 1,
+              display: 'block',
+              color: 'text.secondary',
+            }}
+          >
+            {getCommandString()}
+          </Typography>
+        </Tooltip>
+      </Box>
 
       {/* Output handle */}
       <Handle

--- a/ffmpeg-flow-editor/src/config/options.json
+++ b/ffmpeg-flow-editor/src/config/options.json
@@ -1,0 +1,1694 @@
+[
+  {
+    "__class__": "FFMpegOption",
+    "name": "L",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show license",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "h",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show help",
+    "argname": "topic",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "?",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show help",
+    "argname": "topic",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "help",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show help",
+    "argname": "topic",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "-help",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show help",
+    "argname": "topic",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "version",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show version",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "buildconf",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show build configuration",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "formats",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available formats",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "muxers",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available muxers",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "demuxers",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available demuxers",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "devices",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available devices",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "codecs",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available codecs",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "decoders",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available decoders",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "encoders",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available encoders",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "bsfs",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available bit stream filters",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "protocols",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available protocols",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filters",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available filters",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "pix_fmts",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available pixel formats",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "layouts",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show standard channel layouts",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sample_fmts",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 2,
+    "help": "show available audio sample formats",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dispositions",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available stream dispositions",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "colors",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available color names",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "loglevel",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "set logging level",
+    "argname": "loglevel",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "v",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 1,
+    "help": "set logging level",
+    "argname": "loglevel",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "report",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4,
+    "help": "generate a report",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "max_alloc",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "set maximum size of a single allocated block",
+    "argname": "bytes",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "cpuflags",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "force specific cpu flags",
+    "argname": "flags",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "cpucount",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "force specific cpu count",
+    "argname": "count",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "hide_banner",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "do not show program banner",
+    "argname": "hide_banner",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sources",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 7,
+    "help": "list sources of the input device",
+    "argname": "device",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sinks",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 7,
+    "help": "list sinks of the output device",
+    "argname": "device",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "f",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6528,
+    "help": "force container format (auto-detected otherwise)",
+    "argname": "fmt",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "y",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 0,
+    "help": "overwrite output files",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "n",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 0,
+    "help": "never overwrite output files",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "ignore_unknown",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "Ignore unknown stream types",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "copy_unknown",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "Copy unknown stream types",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "recast_media",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "allow recasting stream type in order to force a decoder of different media type",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "c",
+    "type": "OPT_TYPE_STRING",
+    "flags": 24448,
+    "help": "select encoder/decoder ('copy' to copy stream without reencoding)",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "codec",
+    "type": "OPT_TYPE_STRING",
+    "flags": 16260,
+    "help": "alias for -c (select encoder/decoder)",
+    "argname": "codec",
+    "canon": ".u1.names_alt = alt_codec"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "pre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 14212,
+    "help": "preset name",
+    "argname": "preset",
+    "canon": ".u1.names_alt = alt_pre"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "map",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4229,
+    "help": "set input stream mapping",
+    "argname": "[-]input_file_id[:stream_specifier][,sync_file_id[:stream_specifier]]",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "map_metadata",
+    "type": "OPT_TYPE_STRING",
+    "flags": 4996,
+    "help": "set metadata information of outfile from infile",
+    "argname": "outfile[,metadata]:infile[,metadata]",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "map_chapters",
+    "type": "OPT_TYPE_INT",
+    "flags": 4484,
+    "help": "set chapters mapping",
+    "argname": "input_file_index",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "t",
+    "type": "OPT_TYPE_TIME",
+    "flags": 6528,
+    "help": "stop transcoding after specified duration",
+    "argname": "duration",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "to",
+    "type": "OPT_TYPE_TIME",
+    "flags": 6528,
+    "help": "stop transcoding after specified time is reached",
+    "argname": "time_stop",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "fs",
+    "type": "OPT_TYPE_INT64",
+    "flags": 4484,
+    "help": "set the limit file size in bytes",
+    "argname": "limit_size",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "ss",
+    "type": "OPT_TYPE_TIME",
+    "flags": 6528,
+    "help": "start transcoding at specified time",
+    "argname": "time_off",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sseof",
+    "type": "OPT_TYPE_TIME",
+    "flags": 2436,
+    "help": "set the start time offset relative to EOF",
+    "argname": "time_off",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "seek_timestamp",
+    "type": "OPT_TYPE_INT",
+    "flags": 2436,
+    "help": "enable/disable seeking by timestamp with -ss",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "accurate_seek",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 2436,
+    "help": "enable/disable accurate seeking with -ss",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "isync",
+    "type": "OPT_TYPE_INT",
+    "flags": 2436,
+    "help": "Indicate the input index for sync reference",
+    "argname": "sync ref",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "itsoffset",
+    "type": "OPT_TYPE_TIME",
+    "flags": 2436,
+    "help": "set the input ts offset",
+    "argname": "time_off",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "itsscale",
+    "type": "OPT_TYPE_DOUBLE",
+    "flags": 3972,
+    "help": "set the input ts scale",
+    "argname": "scale",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "timestamp",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4229,
+    "help": "set the recording timestamp ('now' to set the current time)",
+    "argname": "time",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "metadata",
+    "type": "OPT_TYPE_STRING",
+    "flags": 4992,
+    "help": "add metadata",
+    "argname": "key=value",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "program",
+    "type": "OPT_TYPE_STRING",
+    "flags": 4996,
+    "help": "add program with specified streams",
+    "argname": "title=string:st=number...",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stream_group",
+    "type": "OPT_TYPE_STRING",
+    "flags": 4996,
+    "help": "add stream group with specified streams and group type-specific arguments",
+    "argname": "id=number:st=number...",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dframes",
+    "type": "OPT_TYPE_INT64",
+    "flags": 20613,
+    "help": "set the number of data frames to output",
+    "argname": "number",
+    "canon": ".u1.name_canon = \"frames\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "benchmark",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "add timings for benchmarking",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "benchmark_all",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "add timings for each task",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "progress",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "write program-readable progress information",
+    "argname": "url",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stdin",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "enable or disable interaction on standard input",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "timelimit",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "set max runtime in seconds in CPU user time",
+    "argname": "limit",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dump",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "dump each input packet",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "hex",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "when dumping packets, also dump the payload",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "re",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 2436,
+    "help": "read input at native frame rate; equivalent to -readrate 1",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "readrate",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 2436,
+    "help": "read input at specified rate",
+    "argname": "speed",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "readrate_initial_burst",
+    "type": "OPT_TYPE_DOUBLE",
+    "flags": 2436,
+    "help": "The initial amount of input to burst read before imposing any readrate",
+    "argname": "seconds",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "target",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4229,
+    "help": "specify target file type (\\\"vcd\\\", \\\"svcd\\\", \\\"dvd\\\", \\\"dv\\\" or \\\"dv50\\\n        \"with optional prefixes \\\"pal-\\\", \\\"ntsc-\\\" or \\\"film-\\\")",
+    "argname": "type",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "frame_drop_threshold",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4,
+    "help": "frame drop threshold",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "copyts",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "copy timestamps",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "start_at_zero",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "shift input timestamps to start at 0 when using copyts",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "copytb",
+    "type": "OPT_TYPE_INT",
+    "flags": 4,
+    "help": "copy input stream time base when stream copying",
+    "argname": "mode",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "shortest",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4484,
+    "help": "finish encoding within shortest input",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "shortest_buf_duration",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4484,
+    "help": "maximum buffering duration (in seconds) for the -shortest option",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "bitexact",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6532,
+    "help": "bitexact mode",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "apad",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "audio pad",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dts_delta_threshold",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4,
+    "help": "timestamp discontinuity delta threshold",
+    "argname": "threshold",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dts_error_threshold",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4,
+    "help": "timestamp error delta threshold",
+    "argname": "threshold",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "xerror",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "exit on error",
+    "argname": "error",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "abort_on",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "abort on the specified condition flags",
+    "argname": "flags",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "copyinkf",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6020,
+    "help": "copy initial non-keyframes",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "copypriorss",
+    "type": "OPT_TYPE_INT",
+    "flags": 6020,
+    "help": "copy or discard frames before start time",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "frames",
+    "type": "OPT_TYPE_INT64",
+    "flags": 14212,
+    "help": "set the number of frames to output",
+    "argname": "number",
+    "canon": ".u1.names_alt = alt_frames"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "tag",
+    "type": "OPT_TYPE_STRING",
+    "flags": 16260,
+    "help": "force codec tag/fourcc",
+    "argname": "fourcc/tag",
+    "canon": ".u1.names_alt = alt_tag"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "q",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 22404,
+    "help": "use fixed quality scale (VBR)",
+    "argname": "q",
+    "canon": ".u1.name_canon = \"qscale\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "qscale",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 12421,
+    "help": "use fixed quality scale (VBR)",
+    "argname": "q",
+    "canon": ".u1.names_alt = alt_qscale"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "profile",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4229,
+    "help": "set profile",
+    "argname": "profile",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter",
+    "type": "OPT_TYPE_STRING",
+    "flags": 14208,
+    "help": "apply specified filters to audio/video",
+    "argname": "filter_graph",
+    "canon": ".u1.names_alt = alt_filter"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter_threads",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "number of non-complex filter threads",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter_script",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "deprecated, use -/filter",
+    "argname": "filename",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "reinit_filter",
+    "type": "OPT_TYPE_INT",
+    "flags": 3972,
+    "help": "reinit filtergraph on input parameter changes",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter_complex",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "create a complex filtergraph",
+    "argname": "graph_description",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter_complex_threads",
+    "type": "OPT_TYPE_INT",
+    "flags": 4,
+    "help": "number of threads for -filter_complex",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "lavfi",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "create a complex filtergraph",
+    "argname": "graph_description",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter_complex_script",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "deprecated, use -/filter_complex instead",
+    "argname": "filename",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "auto_conversion_filters",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "enable automatic conversion filters globally",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 0,
+    "help": "print progress report during encoding",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_period",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "set the period at which ffmpeg updates stats and -progress output",
+    "argname": "time",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "attach",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4229,
+    "help": "add an attachment to the output file",
+    "argname": "filename",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dump_attachment",
+    "type": "OPT_TYPE_STRING",
+    "flags": 2948,
+    "help": "extract an attachment into a file",
+    "argname": "filename",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stream_loop",
+    "type": "OPT_TYPE_INT",
+    "flags": 2436,
+    "help": "set number of times input stream shall be looped",
+    "argname": "loop count",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "debug_ts",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4,
+    "help": "print timestamp debugging info",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "max_error_rate",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4,
+    "help": "ratio of decoding errors (0.0: no errors, 1.0: 100% errors) above which ffmpeg returns an error instead of success.",
+    "argname": "maximum error rate",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "discard",
+    "type": "OPT_TYPE_STRING",
+    "flags": 3972,
+    "help": "discard",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "disposition",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "disposition",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "thread_queue_size",
+    "type": "OPT_TYPE_INT",
+    "flags": 6532,
+    "help": "set the maximum number of queued packets from the demuxer",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "find_stream_info",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 2436,
+    "help": "read and decode the streams to fill missing information with heuristics",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "bits_per_raw_sample",
+    "type": "OPT_TYPE_INT",
+    "flags": 6020,
+    "help": "set the number of bits per raw sample",
+    "argname": "number",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_enc_pre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "write encoding stats before encoding",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_enc_post",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "write encoding stats after encoding",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_mux_pre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "write packets stats before muxing",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_enc_pre_fmt",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "format of the stats written with -stats_enc_pre",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_enc_post_fmt",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "format of the stats written with -stats_enc_post",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stats_mux_pre_fmt",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "format of the stats written with -stats_mux_pre",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vframes",
+    "type": "OPT_TYPE_INT64",
+    "flags": 20621,
+    "help": "set the number of video frames to output",
+    "argname": "number",
+    "canon": ".u1.name_canon = \"frames\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "r",
+    "type": "OPT_TYPE_STRING",
+    "flags": 8072,
+    "help": "override input framerate/convert to given output framerate (Hz value, fraction or abbreviation)",
+    "argname": "rate",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "fpsmax",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "set max frame rate (Hz value, fraction or abbreviation)",
+    "argname": "rate",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "s",
+    "type": "OPT_TYPE_STRING",
+    "flags": 8104,
+    "help": "set frame size (WxH or abbreviation)",
+    "argname": "size",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "aspect",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6024,
+    "help": "set aspect ratio (4:3, 16:9 or 1.3333, 1.7777)",
+    "argname": "aspect",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "pix_fmt",
+    "type": "OPT_TYPE_STRING",
+    "flags": 8076,
+    "help": "set pixel format",
+    "argname": "format",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "display_rotation",
+    "type": "OPT_TYPE_DOUBLE",
+    "flags": 3980,
+    "help": "set pure counter-clockwise rotation in degrees for stream(s)",
+    "argname": "angle",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "display_hflip",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 3980,
+    "help": "set display horizontal flip for stream(s) (overrides any display rotation if it is not set)",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "display_vflip",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 3980,
+    "help": "set display vertical flip for stream(s) (overrides any display rotation if it is not set)",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vn",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6536,
+    "help": "disable video",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "rc_override",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "rate control override for specific intervals",
+    "argname": "override",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vcodec",
+    "type": "OPT_TYPE_STRING",
+    "flags": 22665,
+    "help": "alias for -c:v (select encoder/decoder for video streams)",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "timecode",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4237,
+    "help": "set initial TimeCode value.",
+    "argname": "hh:mm:ss[:;.]ff",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "pass",
+    "type": "OPT_TYPE_INT",
+    "flags": 6028,
+    "help": "select the pass number (1 to 3)",
+    "argname": "n",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "passlogfile",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "select two pass log file name prefix",
+    "argname": "prefix",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vstats",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 12,
+    "help": "dump video coding statistics to file",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vstats_file",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 13,
+    "help": "dump video coding statistics to file",
+    "argname": "file",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vstats_version",
+    "type": "OPT_TYPE_INT",
+    "flags": 12,
+    "help": "Version of the vstats format to use.",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vf",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20617,
+    "help": "alias for -filter:v (apply filters to video streams)",
+    "argname": "filter_graph",
+    "canon": ".u1.name_canon = \"filter\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "intra_matrix",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "specify intra matrix coeffs",
+    "argname": "matrix",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "inter_matrix",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "specify inter matrix coeffs",
+    "argname": "matrix",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "chroma_intra_matrix",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "specify intra matrix coeffs",
+    "argname": "matrix",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vtag",
+    "type": "OPT_TYPE_STRING",
+    "flags": 22669,
+    "help": "force video tag/fourcc",
+    "argname": "fourcc/tag",
+    "canon": ".u1.name_canon = \"tag\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "fps_mode",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "set framerate mode for matching video streams; overrides vsync",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "force_fps",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6028,
+    "help": "force the selected framerate, disable the best supported framerate selection",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "streamid",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4237,
+    "help": "set the value of an outfile streamid",
+    "argname": "streamIndex:value",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "force_key_frames",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6028,
+    "help": "force key frames at specified timestamps",
+    "argname": "timestamps",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "b",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4233,
+    "help": "video bitrate (please use -b:v)",
+    "argname": "bitrate",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "hwaccel",
+    "type": "OPT_TYPE_STRING",
+    "flags": 3980,
+    "help": "use HW accelerated decoding",
+    "argname": "hwaccel name",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "hwaccel_device",
+    "type": "OPT_TYPE_STRING",
+    "flags": 3980,
+    "help": "select a device for HW acceleration",
+    "argname": "devicename",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "hwaccel_output_format",
+    "type": "OPT_TYPE_STRING",
+    "flags": 3980,
+    "help": "select output format used with HW accelerated decoding",
+    "argname": "format",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "hwaccels",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 6,
+    "help": "show available HW acceleration methods",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "autorotate",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 3972,
+    "help": "automatically insert correct rotate filters",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "autoscale",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6020,
+    "help": "automatically insert a scale filter at the end of the filter graph",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "fix_sub_duration_heartbeat",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6028,
+    "help": "set this video output stream to be a heartbeat stream for fix_sub_duration, according to which subtitles should be split at random access points",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "aframes",
+    "type": "OPT_TYPE_INT64",
+    "flags": 20629,
+    "help": "set the number of audio frames to output",
+    "argname": "number",
+    "canon": ".u1.name_canon = \"frames\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "aq",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4241,
+    "help": "set audio quality (codec-specific)",
+    "argname": "quality",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "ar",
+    "type": "OPT_TYPE_INT",
+    "flags": 8080,
+    "help": "set audio sampling rate (in Hz)",
+    "argname": "rate",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "ac",
+    "type": "OPT_TYPE_INT",
+    "flags": 8080,
+    "help": "set number of audio channels",
+    "argname": "channels",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "an",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6544,
+    "help": "disable audio",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "acodec",
+    "type": "OPT_TYPE_STRING",
+    "flags": 22673,
+    "help": "alias for -c:a (select encoder/decoder for audio streams)",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "ab",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4241,
+    "help": "alias for -b:a (select bitrate for audio streams)",
+    "argname": "bitrate",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "atag",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20629,
+    "help": "force audio tag/fourcc",
+    "argname": "fourcc/tag",
+    "canon": ".u1.name_canon = \"tag\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sample_fmt",
+    "type": "OPT_TYPE_STRING",
+    "flags": 8084,
+    "help": "set sample format",
+    "argname": "format",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "channel_layout",
+    "type": "OPT_TYPE_STRING",
+    "flags": 16276,
+    "help": "set channel layout",
+    "argname": "layout",
+    "canon": ".u1.names_alt = alt_channel_layout"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "ch_layout",
+    "type": "OPT_TYPE_STRING",
+    "flags": 24468,
+    "help": "set channel layout",
+    "argname": "layout",
+    "canon": ".u1.name_canon = \"channel_layout\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "af",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20625,
+    "help": "alias for -filter:a (apply filters to audio streams)",
+    "argname": "filter_graph",
+    "canon": ".u1.name_canon = \"filter\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "guess_layout_max",
+    "type": "OPT_TYPE_INT",
+    "flags": 3988,
+    "help": "set the maximum number of channels to try to guess the channel layout",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sn",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6560,
+    "help": "disable subtitle",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "scodec",
+    "type": "OPT_TYPE_STRING",
+    "flags": 22689,
+    "help": "alias for -c:s (select encoder/decoder for subtitle streams)",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "stag",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20645,
+    "help": "force subtitle tag/fourcc",
+    "argname": "fourcc/tag",
+    "canon": ".u1.name_canon = \"tag\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "fix_sub_duration",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 4004,
+    "help": "fix subtitles duration",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "canvas_size",
+    "type": "OPT_TYPE_STRING",
+    "flags": 4004,
+    "help": "set canvas size (WxH or abbreviation)",
+    "argname": "size",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "muxdelay",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4484,
+    "help": "set the maximum demux-decode delay",
+    "argname": "seconds",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "muxpreload",
+    "type": "OPT_TYPE_FLOAT",
+    "flags": 4484,
+    "help": "set the initial demux-decode delay",
+    "argname": "seconds",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "sdp_file",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 4101,
+    "help": "specify a file in which to print sdp information",
+    "argname": "file",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "time_base",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "set the desired time base hint for output stream (1:24, 1:48000 or 0.04166, 2.0833e-5)",
+    "argname": "ratio",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "enc_time_base",
+    "type": "OPT_TYPE_STRING",
+    "flags": 6020,
+    "help": "set the desired time base for the encoder (1:24, 1:48000 or 0.04166, 2.0833e-5). two special values are defined - 0 = use frame rate (video) or sample rate (audio),-1 = match source time base",
+    "argname": "ratio",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "bsf",
+    "type": "OPT_TYPE_STRING",
+    "flags": 8068,
+    "help": "A comma-separated list of bitstream filters",
+    "argname": "bitstream_filters",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "apre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20629,
+    "help": "set the audio options to the indicated preset",
+    "argname": "preset",
+    "canon": ".u1.name_canon = \"pre\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vpre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20621,
+    "help": "set the video options to the indicated preset",
+    "argname": "preset",
+    "canon": ".u1.name_canon = \"pre\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "spre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20645,
+    "help": "set the subtitle options to the indicated preset",
+    "argname": "preset",
+    "canon": ".u1.name_canon = \"pre\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "fpre",
+    "type": "OPT_TYPE_STRING",
+    "flags": 20613,
+    "help": "set options from indicated preset file",
+    "argname": "filename",
+    "canon": ".u1.name_canon = \"pre\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "max_muxing_queue_size",
+    "type": "OPT_TYPE_INT",
+    "flags": 6020,
+    "help": "maximum number of packets that can be buffered while waiting for all streams to initialize",
+    "argname": "packets",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "muxing_queue_data_threshold",
+    "type": "OPT_TYPE_INT",
+    "flags": 6020,
+    "help": "set the threshold after which max_muxing_queue_size is taken into account",
+    "argname": "bytes",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dcodec",
+    "type": "OPT_TYPE_STRING",
+    "flags": 22725,
+    "help": "alias for -c:d (select encoder/decoder for data streams)",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\""
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "dn",
+    "type": "OPT_TYPE_BOOL",
+    "flags": 6592,
+    "help": "disable data",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "init_hw_device",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "initialise hardware device",
+    "argname": "args",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "filter_hw_device",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "set hardware device used when filtering",
+    "argname": "device",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "adrift_threshold",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "deprecated, does nothing",
+    "argname": "threshold",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "top",
+    "type": "OPT_TYPE_INT",
+    "flags": 8076,
+    "help": "deprecated, use the setfield video filter",
+    "argname": "",
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "qphist",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 12,
+    "help": "deprecated, does nothing",
+    "argname": null,
+    "canon": null
+  },
+  {
+    "__class__": "FFMpegOption",
+    "name": "vsync",
+    "type": "OPT_TYPE_FUNC",
+    "flags": 5,
+    "help": "set video sync method globally; deprecated, use -fps_mode",
+    "argname": "",
+    "canon": null
+  }
+]

--- a/src/ffmpeg/common/cache/list/options.json
+++ b/src/ffmpeg/common/cache/list/options.json
@@ -1,0 +1,1694 @@
+[
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show license",
+    "name": "L",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "topic",
+    "canon": null,
+    "flags": 2,
+    "help": "show help",
+    "name": "h",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "topic",
+    "canon": null,
+    "flags": 6,
+    "help": "show help",
+    "name": "?",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "topic",
+    "canon": null,
+    "flags": 6,
+    "help": "show help",
+    "name": "help",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "topic",
+    "canon": null,
+    "flags": 6,
+    "help": "show help",
+    "name": "-help",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show version",
+    "name": "version",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show build configuration",
+    "name": "buildconf",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available formats",
+    "name": "formats",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available muxers",
+    "name": "muxers",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available demuxers",
+    "name": "demuxers",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available devices",
+    "name": "devices",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available codecs",
+    "name": "codecs",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available decoders",
+    "name": "decoders",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available encoders",
+    "name": "encoders",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available bit stream filters",
+    "name": "bsfs",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available protocols",
+    "name": "protocols",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available filters",
+    "name": "filters",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available pixel formats",
+    "name": "pix_fmts",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show standard channel layouts",
+    "name": "layouts",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2,
+    "help": "show available audio sample formats",
+    "name": "sample_fmts",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available stream dispositions",
+    "name": "dispositions",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available color names",
+    "name": "colors",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "loglevel",
+    "canon": null,
+    "flags": 5,
+    "help": "set logging level",
+    "name": "loglevel",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "loglevel",
+    "canon": null,
+    "flags": 1,
+    "help": "set logging level",
+    "name": "v",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "generate a report",
+    "name": "report",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "bytes",
+    "canon": null,
+    "flags": 5,
+    "help": "set maximum size of a single allocated block",
+    "name": "max_alloc",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "flags",
+    "canon": null,
+    "flags": 5,
+    "help": "force specific cpu flags",
+    "name": "cpuflags",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "count",
+    "canon": null,
+    "flags": 5,
+    "help": "force specific cpu count",
+    "name": "cpucount",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "hide_banner",
+    "canon": null,
+    "flags": 4,
+    "help": "do not show program banner",
+    "name": "hide_banner",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "device",
+    "canon": null,
+    "flags": 7,
+    "help": "list sources of the input device",
+    "name": "sources",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "device",
+    "canon": null,
+    "flags": 7,
+    "help": "list sinks of the output device",
+    "name": "sinks",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "fmt",
+    "canon": null,
+    "flags": 6528,
+    "help": "force container format (auto-detected otherwise)",
+    "name": "f",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 0,
+    "help": "overwrite output files",
+    "name": "y",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 0,
+    "help": "never overwrite output files",
+    "name": "n",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "Ignore unknown stream types",
+    "name": "ignore_unknown",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "Copy unknown stream types",
+    "name": "copy_unknown",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "allow recasting stream type in order to force a decoder of different media type",
+    "name": "recast_media",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\"",
+    "flags": 24448,
+    "help": "select encoder/decoder ('copy' to copy stream without reencoding)",
+    "name": "c",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "codec",
+    "canon": ".u1.names_alt = alt_codec",
+    "flags": 16260,
+    "help": "alias for -c (select encoder/decoder)",
+    "name": "codec",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "preset",
+    "canon": ".u1.names_alt = alt_pre",
+    "flags": 14212,
+    "help": "preset name",
+    "name": "pre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "[-]input_file_id[:stream_specifier][,sync_file_id[:stream_specifier]]",
+    "canon": null,
+    "flags": 4229,
+    "help": "set input stream mapping",
+    "name": "map",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "outfile[,metadata]:infile[,metadata]",
+    "canon": null,
+    "flags": 4996,
+    "help": "set metadata information of outfile from infile",
+    "name": "map_metadata",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "input_file_index",
+    "canon": null,
+    "flags": 4484,
+    "help": "set chapters mapping",
+    "name": "map_chapters",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "duration",
+    "canon": null,
+    "flags": 6528,
+    "help": "stop transcoding after specified duration",
+    "name": "t",
+    "type": "OPT_TYPE_TIME"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "time_stop",
+    "canon": null,
+    "flags": 6528,
+    "help": "stop transcoding after specified time is reached",
+    "name": "to",
+    "type": "OPT_TYPE_TIME"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "limit_size",
+    "canon": null,
+    "flags": 4484,
+    "help": "set the limit file size in bytes",
+    "name": "fs",
+    "type": "OPT_TYPE_INT64"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "time_off",
+    "canon": null,
+    "flags": 6528,
+    "help": "start transcoding at specified time",
+    "name": "ss",
+    "type": "OPT_TYPE_TIME"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "time_off",
+    "canon": null,
+    "flags": 2436,
+    "help": "set the start time offset relative to EOF",
+    "name": "sseof",
+    "type": "OPT_TYPE_TIME"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2436,
+    "help": "enable/disable seeking by timestamp with -ss",
+    "name": "seek_timestamp",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2436,
+    "help": "enable/disable accurate seeking with -ss",
+    "name": "accurate_seek",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "sync ref",
+    "canon": null,
+    "flags": 2436,
+    "help": "Indicate the input index for sync reference",
+    "name": "isync",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "time_off",
+    "canon": null,
+    "flags": 2436,
+    "help": "set the input ts offset",
+    "name": "itsoffset",
+    "type": "OPT_TYPE_TIME"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "scale",
+    "canon": null,
+    "flags": 3972,
+    "help": "set the input ts scale",
+    "name": "itsscale",
+    "type": "OPT_TYPE_DOUBLE"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "time",
+    "canon": null,
+    "flags": 4229,
+    "help": "set the recording timestamp ('now' to set the current time)",
+    "name": "timestamp",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "key=value",
+    "canon": null,
+    "flags": 4992,
+    "help": "add metadata",
+    "name": "metadata",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "title=string:st=number...",
+    "canon": null,
+    "flags": 4996,
+    "help": "add program with specified streams",
+    "name": "program",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "id=number:st=number...",
+    "canon": null,
+    "flags": 4996,
+    "help": "add stream group with specified streams and group type-specific arguments",
+    "name": "stream_group",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "number",
+    "canon": ".u1.name_canon = \"frames\"",
+    "flags": 20613,
+    "help": "set the number of data frames to output",
+    "name": "dframes",
+    "type": "OPT_TYPE_INT64"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "add timings for benchmarking",
+    "name": "benchmark",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "add timings for each task",
+    "name": "benchmark_all",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "url",
+    "canon": null,
+    "flags": 5,
+    "help": "write program-readable progress information",
+    "name": "progress",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "enable or disable interaction on standard input",
+    "name": "stdin",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "limit",
+    "canon": null,
+    "flags": 5,
+    "help": "set max runtime in seconds in CPU user time",
+    "name": "timelimit",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "dump each input packet",
+    "name": "dump",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "when dumping packets, also dump the payload",
+    "name": "hex",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 2436,
+    "help": "read input at native frame rate; equivalent to -readrate 1",
+    "name": "re",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "speed",
+    "canon": null,
+    "flags": 2436,
+    "help": "read input at specified rate",
+    "name": "readrate",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "seconds",
+    "canon": null,
+    "flags": 2436,
+    "help": "The initial amount of input to burst read before imposing any readrate",
+    "name": "readrate_initial_burst",
+    "type": "OPT_TYPE_DOUBLE"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "type",
+    "canon": null,
+    "flags": 4229,
+    "help": "specify target file type (\\\"vcd\\\", \\\"svcd\\\", \\\"dvd\\\", \\\"dv\\\" or \\\"dv50\\\n        \"with optional prefixes \\\"pal-\\\", \\\"ntsc-\\\" or \\\"film-\\\")",
+    "name": "target",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 4,
+    "help": "frame drop threshold",
+    "name": "frame_drop_threshold",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "copy timestamps",
+    "name": "copyts",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "shift input timestamps to start at 0 when using copyts",
+    "name": "start_at_zero",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "mode",
+    "canon": null,
+    "flags": 4,
+    "help": "copy input stream time base when stream copying",
+    "name": "copytb",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4484,
+    "help": "finish encoding within shortest input",
+    "name": "shortest",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4484,
+    "help": "maximum buffering duration (in seconds) for the -shortest option",
+    "name": "shortest_buf_duration",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6532,
+    "help": "bitexact mode",
+    "name": "bitexact",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 6020,
+    "help": "audio pad",
+    "name": "apad",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "threshold",
+    "canon": null,
+    "flags": 4,
+    "help": "timestamp discontinuity delta threshold",
+    "name": "dts_delta_threshold",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "threshold",
+    "canon": null,
+    "flags": 4,
+    "help": "timestamp error delta threshold",
+    "name": "dts_error_threshold",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "error",
+    "canon": null,
+    "flags": 4,
+    "help": "exit on error",
+    "name": "xerror",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "flags",
+    "canon": null,
+    "flags": 5,
+    "help": "abort on the specified condition flags",
+    "name": "abort_on",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "copy initial non-keyframes",
+    "name": "copyinkf",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "copy or discard frames before start time",
+    "name": "copypriorss",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "number",
+    "canon": ".u1.names_alt = alt_frames",
+    "flags": 14212,
+    "help": "set the number of frames to output",
+    "name": "frames",
+    "type": "OPT_TYPE_INT64"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "fourcc/tag",
+    "canon": ".u1.names_alt = alt_tag",
+    "flags": 16260,
+    "help": "force codec tag/fourcc",
+    "name": "tag",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "q",
+    "canon": ".u1.name_canon = \"qscale\"",
+    "flags": 22404,
+    "help": "use fixed quality scale (VBR)",
+    "name": "q",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "q",
+    "canon": ".u1.names_alt = alt_qscale",
+    "flags": 12421,
+    "help": "use fixed quality scale (VBR)",
+    "name": "qscale",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "profile",
+    "canon": null,
+    "flags": 4229,
+    "help": "set profile",
+    "name": "profile",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filter_graph",
+    "canon": ".u1.names_alt = alt_filter",
+    "flags": 14208,
+    "help": "apply specified filters to audio/video",
+    "name": "filter",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 5,
+    "help": "number of non-complex filter threads",
+    "name": "filter_threads",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filename",
+    "canon": null,
+    "flags": 6020,
+    "help": "deprecated, use -/filter",
+    "name": "filter_script",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 3972,
+    "help": "reinit filtergraph on input parameter changes",
+    "name": "reinit_filter",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "graph_description",
+    "canon": null,
+    "flags": 5,
+    "help": "create a complex filtergraph",
+    "name": "filter_complex",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "number of threads for -filter_complex",
+    "name": "filter_complex_threads",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "graph_description",
+    "canon": null,
+    "flags": 5,
+    "help": "create a complex filtergraph",
+    "name": "lavfi",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filename",
+    "canon": null,
+    "flags": 5,
+    "help": "deprecated, use -/filter_complex instead",
+    "name": "filter_complex_script",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "enable automatic conversion filters globally",
+    "name": "auto_conversion_filters",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 0,
+    "help": "print progress report during encoding",
+    "name": "stats",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "time",
+    "canon": null,
+    "flags": 5,
+    "help": "set the period at which ffmpeg updates stats and -progress output",
+    "name": "stats_period",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filename",
+    "canon": null,
+    "flags": 4229,
+    "help": "add an attachment to the output file",
+    "name": "attach",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filename",
+    "canon": null,
+    "flags": 2948,
+    "help": "extract an attachment into a file",
+    "name": "dump_attachment",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "loop count",
+    "canon": null,
+    "flags": 2436,
+    "help": "set number of times input stream shall be looped",
+    "name": "stream_loop",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4,
+    "help": "print timestamp debugging info",
+    "name": "debug_ts",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "maximum error rate",
+    "canon": null,
+    "flags": 4,
+    "help": "ratio of decoding errors (0.0: no errors, 1.0: 100% errors) above which ffmpeg returns an error instead of success.",
+    "name": "max_error_rate",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 3972,
+    "help": "discard",
+    "name": "discard",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 6020,
+    "help": "disposition",
+    "name": "disposition",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6532,
+    "help": "set the maximum number of queued packets from the demuxer",
+    "name": "thread_queue_size",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 2436,
+    "help": "read and decode the streams to fill missing information with heuristics",
+    "name": "find_stream_info",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "number",
+    "canon": null,
+    "flags": 6020,
+    "help": "set the number of bits per raw sample",
+    "name": "bits_per_raw_sample",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "write encoding stats before encoding",
+    "name": "stats_enc_pre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "write encoding stats after encoding",
+    "name": "stats_enc_post",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "write packets stats before muxing",
+    "name": "stats_mux_pre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "format of the stats written with -stats_enc_pre",
+    "name": "stats_enc_pre_fmt",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "format of the stats written with -stats_enc_post",
+    "name": "stats_enc_post_fmt",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "format of the stats written with -stats_mux_pre",
+    "name": "stats_mux_pre_fmt",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "number",
+    "canon": ".u1.name_canon = \"frames\"",
+    "flags": 20621,
+    "help": "set the number of video frames to output",
+    "name": "vframes",
+    "type": "OPT_TYPE_INT64"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "rate",
+    "canon": null,
+    "flags": 8072,
+    "help": "override input framerate/convert to given output framerate (Hz value, fraction or abbreviation)",
+    "name": "r",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "rate",
+    "canon": null,
+    "flags": 6028,
+    "help": "set max frame rate (Hz value, fraction or abbreviation)",
+    "name": "fpsmax",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "size",
+    "canon": null,
+    "flags": 8104,
+    "help": "set frame size (WxH or abbreviation)",
+    "name": "s",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "aspect",
+    "canon": null,
+    "flags": 6024,
+    "help": "set aspect ratio (4:3, 16:9 or 1.3333, 1.7777)",
+    "name": "aspect",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "format",
+    "canon": null,
+    "flags": 8076,
+    "help": "set pixel format",
+    "name": "pix_fmt",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "angle",
+    "canon": null,
+    "flags": 3980,
+    "help": "set pure counter-clockwise rotation in degrees for stream(s)",
+    "name": "display_rotation",
+    "type": "OPT_TYPE_DOUBLE"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 3980,
+    "help": "set display horizontal flip for stream(s) (overrides any display rotation if it is not set)",
+    "name": "display_hflip",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 3980,
+    "help": "set display vertical flip for stream(s) (overrides any display rotation if it is not set)",
+    "name": "display_vflip",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6536,
+    "help": "disable video",
+    "name": "vn",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "override",
+    "canon": null,
+    "flags": 6028,
+    "help": "rate control override for specific intervals",
+    "name": "rc_override",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\"",
+    "flags": 22665,
+    "help": "alias for -c:v (select encoder/decoder for video streams)",
+    "name": "vcodec",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "hh:mm:ss[:;.]ff",
+    "canon": null,
+    "flags": 4237,
+    "help": "set initial TimeCode value.",
+    "name": "timecode",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "n",
+    "canon": null,
+    "flags": 6028,
+    "help": "select the pass number (1 to 3)",
+    "name": "pass",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "prefix",
+    "canon": null,
+    "flags": 6028,
+    "help": "select two pass log file name prefix",
+    "name": "passlogfile",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 12,
+    "help": "dump video coding statistics to file",
+    "name": "vstats",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "file",
+    "canon": null,
+    "flags": 13,
+    "help": "dump video coding statistics to file",
+    "name": "vstats_file",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 12,
+    "help": "Version of the vstats format to use.",
+    "name": "vstats_version",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filter_graph",
+    "canon": ".u1.name_canon = \"filter\"",
+    "flags": 20617,
+    "help": "alias for -filter:v (apply filters to video streams)",
+    "name": "vf",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "matrix",
+    "canon": null,
+    "flags": 6028,
+    "help": "specify intra matrix coeffs",
+    "name": "intra_matrix",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "matrix",
+    "canon": null,
+    "flags": 6028,
+    "help": "specify inter matrix coeffs",
+    "name": "inter_matrix",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "matrix",
+    "canon": null,
+    "flags": 6028,
+    "help": "specify intra matrix coeffs",
+    "name": "chroma_intra_matrix",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "fourcc/tag",
+    "canon": ".u1.name_canon = \"tag\"",
+    "flags": 22669,
+    "help": "force video tag/fourcc",
+    "name": "vtag",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6028,
+    "help": "set framerate mode for matching video streams; overrides vsync",
+    "name": "fps_mode",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6028,
+    "help": "force the selected framerate, disable the best supported framerate selection",
+    "name": "force_fps",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "streamIndex:value",
+    "canon": null,
+    "flags": 4237,
+    "help": "set the value of an outfile streamid",
+    "name": "streamid",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "timestamps",
+    "canon": null,
+    "flags": 6028,
+    "help": "force key frames at specified timestamps",
+    "name": "force_key_frames",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "bitrate",
+    "canon": null,
+    "flags": 4233,
+    "help": "video bitrate (please use -b:v)",
+    "name": "b",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "hwaccel name",
+    "canon": null,
+    "flags": 3980,
+    "help": "use HW accelerated decoding",
+    "name": "hwaccel",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "devicename",
+    "canon": null,
+    "flags": 3980,
+    "help": "select a device for HW acceleration",
+    "name": "hwaccel_device",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "format",
+    "canon": null,
+    "flags": 3980,
+    "help": "select output format used with HW accelerated decoding",
+    "name": "hwaccel_output_format",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6,
+    "help": "show available HW acceleration methods",
+    "name": "hwaccels",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 3972,
+    "help": "automatically insert correct rotate filters",
+    "name": "autorotate",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6020,
+    "help": "automatically insert a scale filter at the end of the filter graph",
+    "name": "autoscale",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6028,
+    "help": "set this video output stream to be a heartbeat stream for fix_sub_duration, according to which subtitles should be split at random access points",
+    "name": "fix_sub_duration_heartbeat",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "number",
+    "canon": ".u1.name_canon = \"frames\"",
+    "flags": 20629,
+    "help": "set the number of audio frames to output",
+    "name": "aframes",
+    "type": "OPT_TYPE_INT64"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "quality",
+    "canon": null,
+    "flags": 4241,
+    "help": "set audio quality (codec-specific)",
+    "name": "aq",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "rate",
+    "canon": null,
+    "flags": 8080,
+    "help": "set audio sampling rate (in Hz)",
+    "name": "ar",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "channels",
+    "canon": null,
+    "flags": 8080,
+    "help": "set number of audio channels",
+    "name": "ac",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6544,
+    "help": "disable audio",
+    "name": "an",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\"",
+    "flags": 22673,
+    "help": "alias for -c:a (select encoder/decoder for audio streams)",
+    "name": "acodec",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "bitrate",
+    "canon": null,
+    "flags": 4241,
+    "help": "alias for -b:a (select bitrate for audio streams)",
+    "name": "ab",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "fourcc/tag",
+    "canon": ".u1.name_canon = \"tag\"",
+    "flags": 20629,
+    "help": "force audio tag/fourcc",
+    "name": "atag",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "format",
+    "canon": null,
+    "flags": 8084,
+    "help": "set sample format",
+    "name": "sample_fmt",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "layout",
+    "canon": ".u1.names_alt = alt_channel_layout",
+    "flags": 16276,
+    "help": "set channel layout",
+    "name": "channel_layout",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "layout",
+    "canon": ".u1.name_canon = \"channel_layout\"",
+    "flags": 24468,
+    "help": "set channel layout",
+    "name": "ch_layout",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filter_graph",
+    "canon": ".u1.name_canon = \"filter\"",
+    "flags": 20625,
+    "help": "alias for -filter:a (apply filters to audio streams)",
+    "name": "af",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 3988,
+    "help": "set the maximum number of channels to try to guess the channel layout",
+    "name": "guess_layout_max",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6560,
+    "help": "disable subtitle",
+    "name": "sn",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\"",
+    "flags": 22689,
+    "help": "alias for -c:s (select encoder/decoder for subtitle streams)",
+    "name": "scodec",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "fourcc/tag",
+    "canon": ".u1.name_canon = \"tag\"",
+    "flags": 20645,
+    "help": "force subtitle tag/fourcc",
+    "name": "stag",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 4004,
+    "help": "fix subtitles duration",
+    "name": "fix_sub_duration",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "size",
+    "canon": null,
+    "flags": 4004,
+    "help": "set canvas size (WxH or abbreviation)",
+    "name": "canvas_size",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "seconds",
+    "canon": null,
+    "flags": 4484,
+    "help": "set the maximum demux-decode delay",
+    "name": "muxdelay",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "seconds",
+    "canon": null,
+    "flags": 4484,
+    "help": "set the initial demux-decode delay",
+    "name": "muxpreload",
+    "type": "OPT_TYPE_FLOAT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "file",
+    "canon": null,
+    "flags": 4101,
+    "help": "specify a file in which to print sdp information",
+    "name": "sdp_file",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "ratio",
+    "canon": null,
+    "flags": 6020,
+    "help": "set the desired time base hint for output stream (1:24, 1:48000 or 0.04166, 2.0833e-5)",
+    "name": "time_base",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "ratio",
+    "canon": null,
+    "flags": 6020,
+    "help": "set the desired time base for the encoder (1:24, 1:48000 or 0.04166, 2.0833e-5). two special values are defined - 0 = use frame rate (video) or sample rate (audio),-1 = match source time base",
+    "name": "enc_time_base",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "bitstream_filters",
+    "canon": null,
+    "flags": 8068,
+    "help": "A comma-separated list of bitstream filters",
+    "name": "bsf",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "preset",
+    "canon": ".u1.name_canon = \"pre\"",
+    "flags": 20629,
+    "help": "set the audio options to the indicated preset",
+    "name": "apre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "preset",
+    "canon": ".u1.name_canon = \"pre\"",
+    "flags": 20621,
+    "help": "set the video options to the indicated preset",
+    "name": "vpre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "preset",
+    "canon": ".u1.name_canon = \"pre\"",
+    "flags": 20645,
+    "help": "set the subtitle options to the indicated preset",
+    "name": "spre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "filename",
+    "canon": ".u1.name_canon = \"pre\"",
+    "flags": 20613,
+    "help": "set options from indicated preset file",
+    "name": "fpre",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "packets",
+    "canon": null,
+    "flags": 6020,
+    "help": "maximum number of packets that can be buffered while waiting for all streams to initialize",
+    "name": "max_muxing_queue_size",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "bytes",
+    "canon": null,
+    "flags": 6020,
+    "help": "set the threshold after which max_muxing_queue_size is taken into account",
+    "name": "muxing_queue_data_threshold",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "codec",
+    "canon": ".u1.name_canon = \"codec\"",
+    "flags": 22725,
+    "help": "alias for -c:d (select encoder/decoder for data streams)",
+    "name": "dcodec",
+    "type": "OPT_TYPE_STRING"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 6592,
+    "help": "disable data",
+    "name": "dn",
+    "type": "OPT_TYPE_BOOL"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "args",
+    "canon": null,
+    "flags": 5,
+    "help": "initialise hardware device",
+    "name": "init_hw_device",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "device",
+    "canon": null,
+    "flags": 5,
+    "help": "set hardware device used when filtering",
+    "name": "filter_hw_device",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "threshold",
+    "canon": null,
+    "flags": 5,
+    "help": "deprecated, does nothing",
+    "name": "adrift_threshold",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 8076,
+    "help": "deprecated, use the setfield video filter",
+    "name": "top",
+    "type": "OPT_TYPE_INT"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": null,
+    "canon": null,
+    "flags": 12,
+    "help": "deprecated, does nothing",
+    "name": "qphist",
+    "type": "OPT_TYPE_FUNC"
+  },
+  {
+    "__class__": "FFMpegOption",
+    "argname": "",
+    "canon": null,
+    "flags": 5,
+    "help": "set video sync method globally; deprecated, use -fps_mode",
+    "name": "vsync",
+    "type": "OPT_TYPE_FUNC"
+  }
+]

--- a/src/scripts/code_gen/cli.py
+++ b/src/scripts/code_gen/cli.py
@@ -41,7 +41,14 @@ def gen_option_info() -> list[FFMpegOption]:
     Returns:
         The option info
     """
-    return parse_ffmpeg_options()
+    try:
+        return load(list[FFMpegOption], "options")
+    except Exception as e:
+        logging.error(f"Failed to load options from cache: {e}")
+
+    options = parse_ffmpeg_options()
+    save(options, "options")
+    return options
 
 
 def load_filters(outpath: Path, rebuild: bool) -> list[FFMpegFilter]:


### PR DESCRIPTION
This pull request introduces significant enhancements to the FFmpeg Flow Editor by improving node handling, adding dynamic parameter management for nodes, and optimizing the options caching mechanism. Below are the key changes grouped by theme:

### Node Type Handling
* Updated `FFmpegFlowEditor.tsx` to append an underscore (`_`) to the `type` property for `input` and `output` nodes, ensuring unique identifiers and avoiding potential conflicts. (`[[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L30-R31)`, `[[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R162-R173)`)

### Dynamic Parameter Management for Nodes
* **GlobalNode (`GlobalNode.tsx`)**: Introduced dynamic parameter handling for global options, including a filtered list of options that exclude input/output flags and unsupported types. Added a command-line representation tooltip for better usability. (`[ffmpeg-flow-editor/src/components/GlobalNode.tsxL1-R111](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304L1-R111)`)
* **InputNode (`InputNode.tsx`)**: Added support for dynamically managing input-specific parameters and filenames, along with a command-line representation tooltip. Parameters are updated via a custom event. (`[ffmpeg-flow-editor/src/components/InputNode.tsxL1-R146](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31L1-R146)`)
* **OutputNode (`OutputNode.tsx`)**: Implemented similar dynamic parameter handling for output-specific parameters and filenames, with a tooltip for command-line representation. (`[ffmpeg-flow-editor/src/components/OutputNode.tsxL1-R146](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccL1-R146)`)

### Options Caching Mechanism
* Updated `cli.py` to add caching for FFmpeg options. If cached options fail to load, the script falls back to parsing options and saves them for future use, improving performance and reliability. (`[src/scripts/code_gen/cli.pyL44-R51](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L44-R51)`)