### PR TITLE
fix #555 assign filename

### DIFF
--- a/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
+++ b/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
@@ -29,8 +29,6 @@ import {
   FilterableStream,
   OutputStream,
   StreamType,
-  InputNode as DAGInputNode,
-  OutputNode as DAGOutputNode,
 } from '../types/dag';
 import { NodeData } from '../types/node';
 
@@ -169,9 +167,8 @@ const createNode = (
   }
 
   const nodeId = nodeMappingManager.addNodeToMapping(mappingData);
-  const node = nodeMappingManager.getNodeMapping().nodeMap.get(nodeId);
   let filename: string | undefined;
-  if (node && (node instanceof DAGInputNode || node instanceof DAGOutputNode)) {
+  if (nodeType == 'input' || nodeType == 'output') {
     filename = node.filename;
   }
 

--- a/ffmpeg-flow-editor/src/utils/nodeMapping.ts
+++ b/ffmpeg-flow-editor/src/utils/nodeMapping.ts
@@ -162,7 +162,7 @@ export class NodeMappingManager {
     let node: FilterNode | InputNode | OutputNode;
     let filterInputs: (FilterableStream | null)[] | undefined;
     let outputInputs: (FilterableStream | null)[] | undefined;
-    let inputFilename: string;
+    const inputFilename: string;
     let outputFilename: string;
 
     switch (params.type) {

--- a/ffmpeg-flow-editor/src/utils/nodeMapping.ts
+++ b/ffmpeg-flow-editor/src/utils/nodeMapping.ts
@@ -60,6 +60,12 @@ export class NodeMappingManager {
   private globalNodeId: string;
   private eventEmitter = new EventEmitter();
 
+  // Helper function to generate random filename
+  private generateRandomFilename(type: 'input' | 'output'): string {
+    const randomId = Math.random().toString(36).substring(2, 8);
+    return `${type}-${randomId}.mp4`;
+  }
+
   constructor() {
     // Initialize the global node
     this.globalNode = new GlobalNode([], {});
@@ -156,6 +162,8 @@ export class NodeMappingManager {
     let node: FilterNode | InputNode | OutputNode;
     let filterInputs: (FilterableStream | null)[] | undefined;
     let outputInputs: (FilterableStream | null)[] | undefined;
+    let inputFilename: string;
+    let outputFilename: string;
 
     switch (params.type) {
       case 'filter':
@@ -176,25 +184,18 @@ export class NodeMappingManager {
         break;
 
       case 'input':
-        if (!params.filename) {
-          throw new Error('InputNode requires filename');
-        }
-        node = new InputNode(params.filename, [], params.kwargs);
+        // Generate random filename if not provided
+        inputFilename = params.filename || this.generateRandomFilename('input');
+        node = new InputNode(inputFilename, [], params.kwargs);
         break;
 
       case 'output':
-        if (!params.filename) {
-          throw new Error('OutputNode requires filename');
-        }
-
+        // Generate random filename if not provided
+        outputFilename = params.filename || this.generateRandomFilename('output');
         // Initialize with a single null input if none provided
-        outputInputs = params.inputs || [null];
+        outputInputs = params.inputs ? (params.inputs as (FilterableStream | null)[]) : [null];
 
-        node = new OutputNode(
-          params.filename,
-          outputInputs as (FilterableStream | null)[],
-          params.kwargs
-        );
+        node = new OutputNode(outputFilename, outputInputs, params.kwargs);
         break;
 
       default:

--- a/ffmpeg-flow-editor/src/utils/nodeMapping.ts
+++ b/ffmpeg-flow-editor/src/utils/nodeMapping.ts
@@ -162,7 +162,7 @@ export class NodeMappingManager {
     let node: FilterNode | InputNode | OutputNode;
     let filterInputs: (FilterableStream | null)[] | undefined;
     let outputInputs: (FilterableStream | null)[] | undefined;
-    const inputFilename: string;
+    let inputFilename: string;
     let outputFilename: string;
 
     switch (params.type) {


### PR DESCRIPTION
fix #555 

This pull request introduces several updates to improve the functionality and maintainability of the `FFmpegFlowEditor` component and its associated utilities. The most notable changes include adding support for dynamically generated filenames for input and output nodes, improving code readability, and addressing minor formatting issues.

### Enhancements to Node Management:
* Added a helper function `generateRandomFilename` in `NodeMappingManager` to generate random filenames for input and output nodes when none are provided. This ensures that nodes always have unique and valid filenames. (`ffmpeg-flow-editor/src/utils/nodeMapping.ts`, [[1]](diffhunk://#diff-d28b146241e7ff913dd7b4873ce82008b03a9e38fc5b7e6e054cc3d54c9c5120R63-R68) [[2]](diffhunk://#diff-d28b146241e7ff913dd7b4873ce82008b03a9e38fc5b7e6e054cc3d54c9c5120L179-R198)
* Updated the `createNode` function to retrieve and assign filenames for `DAGInputNode` and `DAGOutputNode` instances, ensuring consistent filename handling. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R172-R182) [[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R196)

### Code Readability Improvements:
* Reformatted multiline type definitions and conditional expressions for better readability and consistency. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L52-R72) [[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L298-R314) [[3]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L323-R341)
* Updated the `Sidebar` component usage to a single-line format for cleaner JSX. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxL456-R474](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L456-R474))

### Bug Fixes and Minor Adjustments:
* Removed hardcoded filenames (`input.mp4` and `output.mp4`) from the `createNode` function, delegating filename assignment to the `NodeMappingManager`. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L102) [[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L115)
* Improved error handling in `updateNode` to ensure proper updates and throw meaningful errors when nodes are not found. (`ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx`, [ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsxR279-R281](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R279-R281))