### PR TITLE
fix filename handle

### DIFF
--- a/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
+++ b/ffmpeg-flow-editor/src/components/FFmpegFlowEditor.tsx
@@ -51,6 +51,12 @@ const getEdgeTypeFromStream = (stream: Stream): EdgeType => {
   return 'av'; // Default fallback
 };
 
+// Helper to generate random filename
+function generateRandomFilename(type: 'input' | 'output'): string {
+  const randomId = Math.random().toString(36).substring(2, 8);
+  return `${type}-${randomId}.mp4`;
+}
+
 // Helper function to create a node
 const createNode = (
   filterType: string,
@@ -79,6 +85,7 @@ const createNode = (
     kwargs: Record<string, string>;
   };
   let nodeType: string;
+  let filename: string | undefined;
 
   if (filterType == 'global') {
     nodeType = 'global';
@@ -108,10 +115,12 @@ const createNode = (
         inputs: [],
         outputs: [{ id: 'output-0', type: 'av' }],
       };
+      filename = parameters?.filename || generateRandomFilename('input');
       mappingData = {
         type: 'input',
         inputs: [],
         kwargs: parameters || {},
+        filename: filename,
       };
       break;
     case 'output':
@@ -120,10 +129,12 @@ const createNode = (
         inputs: [{ id: 'input-0', type: 'av' }],
         outputs: [{ id: 'output-0', type: 'av' }],
       };
+      filename = parameters?.filename || generateRandomFilename('output');
       mappingData = {
         type: 'output',
         inputs: [],
         kwargs: parameters || {},
+        filename: filename,
       };
       break;
     case 'filter':
@@ -167,11 +178,6 @@ const createNode = (
   }
 
   const nodeId = nodeMappingManager.addNodeToMapping(mappingData);
-  let filename: string | undefined;
-  if (nodeType == 'input' || nodeType == 'output') {
-    filename = node.filename;
-  }
-
   // if nodeType is input or output add a `_` to the end of the nodeType
   let nodeType_: string;
   if (nodeType === 'input' || nodeType === 'output') {

--- a/ffmpeg-flow-editor/src/utils/nodeMapping.ts
+++ b/ffmpeg-flow-editor/src/utils/nodeMapping.ts
@@ -60,12 +60,6 @@ export class NodeMappingManager {
   private globalNodeId: string;
   private eventEmitter = new EventEmitter();
 
-  // Helper function to generate random filename
-  private generateRandomFilename(type: 'input' | 'output'): string {
-    const randomId = Math.random().toString(36).substring(2, 8);
-    return `${type}-${randomId}.mp4`;
-  }
-
   constructor() {
     // Initialize the global node
     this.globalNode = new GlobalNode([], {});
@@ -185,13 +179,19 @@ export class NodeMappingManager {
 
       case 'input':
         // Generate random filename if not provided
-        inputFilename = params.filename || this.generateRandomFilename('input');
+        if (!params.filename) {
+          throw new Error('InputNode requires filename');
+        }
+        inputFilename = params.filename;
         node = new InputNode(inputFilename, [], params.kwargs);
         break;
 
       case 'output':
         // Generate random filename if not provided
-        outputFilename = params.filename || this.generateRandomFilename('output');
+        if (!params.filename) {
+          throw new Error('OutputNode requires filename');
+        }
+        outputFilename = params.filename;
         // Initialize with a single null input if none provided
         outputInputs = params.inputs ? (params.inputs as (FilterableStream | null)[]) : [null];
 


### PR DESCRIPTION
This pull request refactors how filenames are handled for input and output nodes in the FFmpeg Flow Editor. The main changes include moving the responsibility for generating random filenames from `NodeMappingManager` to `FFmpegFlowEditor`, ensuring that filenames are explicitly required when creating nodes in `NodeMappingManager`, and simplifying the code structure.

### Refactoring of Filename Handling:

* **Moved `generateRandomFilename` to `FFmpegFlowEditor`:** The helper function `generateRandomFilename` was removed from `NodeMappingManager` and added to `FFmpegFlowEditor`, centralizing the logic for generating random filenames in the UI layer. (`[[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R54-R59)`, `[[2]](diffhunk://#diff-d28b146241e7ff913dd7b4873ce82008b03a9e38fc5b7e6e054cc3d54c9c5120L63-L68)`)

* **Explicit filename requirement in `NodeMappingManager`:** The `NodeMappingManager` now throws an error if a filename is not provided for input or output nodes, enforcing stricter validation. (`[ffmpeg-flow-editor/src/utils/nodeMapping.tsL188-R194](diffhunk://#diff-d28b146241e7ff913dd7b4873ce82008b03a9e38fc5b7e6e054cc3d54c9c5120L188-R194)`)

### Code Simplification:

* **Removed redundant filename logic in `createNode`:** The logic for handling filenames in `createNode` was simplified by directly using the `generateRandomFilename` helper in `FFmpegFlowEditor` when needed. (`[[1]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R118-R123)`, `[[2]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46R132-R137)`, `[[3]](diffhunk://#diff-c78d5be125a6181cec3e91036100bd44c400b29460d73ec0964f0206f067aa46L170-L174)`)

These changes improve code clarity, enforce better validation, and separate concerns between the UI and backend logic.