### PR TITLE
Fix 476 more and less

### DIFF
--- a/ffmpeg-flow-editor/src/components/FilterNode.tsx
+++ b/ffmpeg-flow-editor/src/components/FilterNode.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Paper, Typography, TextField, Box, Tooltip, useTheme } from '@mui/material';
+import { Paper, Typography, TextField, Box, Tooltip, useTheme, Button } from '@mui/material';
 import { FFmpegFilterOption, predefinedFilters, FFMpegIOType } from '../types/ffmpeg';
 import { EdgeType, EDGE_COLORS } from '../types/edge';
 import { NodeData } from '../types/node';
@@ -13,6 +13,7 @@ function FilterNode({ data, id }: NodeProps<NodeData>) {
   const theme = useTheme();
   const [parameters, setParameters] = useState<Record<string, string>>(data.parameters || {});
   const [errors, setErrors] = useState<ValidationError>({});
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   // Update local state when data changes
   useEffect(() => {
@@ -107,6 +108,9 @@ function FilterNode({ data, id }: NodeProps<NodeData>) {
   const inputTypes = filter.stream_typings_input;
   const outputTypes = filter.stream_typings_output;
 
+  // Calculate which options to show
+  const visibleOptions = expanded ? filter.options : filter.options.slice(0, 3);
+
   return (
     <Paper
       elevation={3}
@@ -116,6 +120,7 @@ function FilterNode({ data, id }: NodeProps<NodeData>) {
         backgroundColor: theme.palette.background.paper,
         border: `1px solid ${theme.palette.divider}`,
         color: theme.palette.text.primary,
+        position: 'relative',
       }}
     >
       {/* Input handles */}
@@ -142,16 +147,38 @@ function FilterNode({ data, id }: NodeProps<NodeData>) {
         );
       })}
 
-      <Typography variant="h6" gutterBottom>
-        {data.label}
-      </Typography>
+      <Box sx={{ 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'flex-start',
+        mb: 1
+      }}>
+        <Typography variant="h6">
+          {data.label}
+        </Typography>
+        
+        {filter.options.length > 3 && (
+          <Button 
+            size="small" 
+            onClick={() => setExpanded(!expanded)}
+            sx={{ 
+              minWidth: 'auto', 
+              fontSize: '0.75rem',
+              padding: '2px 8px',
+            }}
+          >
+            {expanded ? 'Less' : 'More'}
+          </Button>
+        )}
+      </Box>
+
       <Box sx={{ mt: 1 }}>
         {filter.description && (
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
             {filter.description}
           </Typography>
         )}
-        {filter.options.map((param) => (
+        {visibleOptions.map((param) => (
           <Box key={param.name} sx={{ mt: 1 }}>
             <TextField
               fullWidth

--- a/ffmpeg-flow-editor/src/components/GlobalNode.tsx
+++ b/ffmpeg-flow-editor/src/components/GlobalNode.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Paper, Typography, TextField, Box, Tooltip, useTheme } from '@mui/material';
+import { Paper, Typography, TextField, Box, Tooltip, Button, useTheme } from '@mui/material';
 import { EDGE_COLORS } from '../types/edge';
 import { NodeData } from '../types/node';
 import options from '../config/options.json';
@@ -19,6 +19,7 @@ const globalOptions = options.filter((option) =>
 function GlobalNode({ data, id }: NodeProps<NodeData>) {
   const theme = useTheme();
   const [parameters, setParameters] = useState<Record<string, string>>(data.parameters || {});
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   // Update local state when data changes
   useEffect(() => {
@@ -55,6 +56,9 @@ function GlobalNode({ data, id }: NodeProps<NodeData>) {
     return paramString;
   };
 
+  // Calculate which options to show
+  const visibleOptions = expanded ? globalOptions : globalOptions.slice(0, 3);
+
   return (
     <Paper 
       elevation={3} 
@@ -64,14 +68,36 @@ function GlobalNode({ data, id }: NodeProps<NodeData>) {
         backgroundColor: '#f3e5f5',
         border: `2px solid #9c27b0`,
         color: theme.palette.text.primary,
+        position: 'relative',
       }}
     >
-      <Typography variant="h6" gutterBottom>
-        {data.label}
-      </Typography>
+      <Box sx={{ 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'flex-start',
+        mb: 1
+      }}>
+        <Typography variant="h6">
+          {data.label}
+        </Typography>
+        
+        {globalOptions.length > 3 && (
+          <Button 
+            size="small" 
+            onClick={() => setExpanded(!expanded)}
+            sx={{ 
+              minWidth: 'auto', 
+              fontSize: '0.75rem',
+              padding: '2px 8px',
+            }}
+          >
+            {expanded ? 'Less' : 'More'}
+          </Button>
+        )}
+      </Box>
 
       <Box sx={{ mt: 1 }}>
-        {globalOptions.map((option) => (
+        {visibleOptions.map((option) => (
           <Box key={option.name} sx={{ mt: 1 }}>
             <TextField
               fullWidth

--- a/ffmpeg-flow-editor/src/components/InputNode.tsx
+++ b/ffmpeg-flow-editor/src/components/InputNode.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Paper, Typography, TextField, Box, Tooltip, useTheme } from '@mui/material';
+import { Paper, Typography, TextField, Box, Tooltip, Button, useTheme } from '@mui/material';
 import { EDGE_COLORS } from '../types/edge';
 import { NodeData } from '../types/node';
 import options from '../config/options.json';
@@ -16,6 +16,7 @@ function InputNode({ data, id }: NodeProps<NodeData>) {
   const theme = useTheme();
   const [filename, setFilename] = useState<string>(data.filename || '');
   const [parameters, setParameters] = useState<Record<string, string>>(data.parameters || {});
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   // Update local state when data changes
   useEffect(() => {
@@ -72,6 +73,9 @@ function InputNode({ data, id }: NodeProps<NodeData>) {
     return `-i ${filename} ${paramString}`;
   };
 
+  // Calculate which options to show
+  const visibleOptions = expanded ? inputOptions : inputOptions.slice(0, 3);
+
   return (
     <Paper 
       elevation={3} 
@@ -81,11 +85,33 @@ function InputNode({ data, id }: NodeProps<NodeData>) {
         backgroundColor: '#e8f5e9',
         border: '2px solid #4caf50',
         color: theme.palette.text.primary,
+        position: 'relative',
       }}
     >
-      <Typography variant="h6" gutterBottom>
-        {data.label}
-      </Typography>
+      <Box sx={{ 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'flex-start',
+        mb: 1
+      }}>
+        <Typography variant="h6">
+          {data.label}
+        </Typography>
+        
+        {inputOptions.length > 3 && (
+          <Button 
+            size="small" 
+            onClick={() => setExpanded(!expanded)}
+            sx={{ 
+              minWidth: 'auto', 
+              fontSize: '0.75rem',
+              padding: '2px 8px',
+            }}
+          >
+            {expanded ? 'Less' : 'More'}
+          </Button>
+        )}
+      </Box>
       
       <Box sx={{ mt: 1 }}>
         <TextField
@@ -107,7 +133,7 @@ function InputNode({ data, id }: NodeProps<NodeData>) {
           }}
         />
 
-        {inputOptions.map((option) => (
+        {visibleOptions.map((option) => (
           <Box key={option.name} sx={{ mt: 1 }}>
             <TextField
               fullWidth

--- a/ffmpeg-flow-editor/src/components/OutputNode.tsx
+++ b/ffmpeg-flow-editor/src/components/OutputNode.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Paper, Typography, TextField, Box, Tooltip, useTheme } from '@mui/material';
+import { Paper, Typography, TextField, Box, Tooltip, Button, useTheme } from '@mui/material';
 import { EDGE_COLORS } from '../types/edge';
 import { NodeData } from '../types/node';
 import options from '../config/options.json';
@@ -16,6 +16,7 @@ function OutputNode({ data, id }: NodeProps<NodeData>) {
   const theme = useTheme();
   const [filename, setFilename] = useState<string>(data.filename || '');
   const [parameters, setParameters] = useState<Record<string, string>>(data.parameters || {});
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   // Update local state when data changes
   useEffect(() => {
@@ -72,6 +73,9 @@ function OutputNode({ data, id }: NodeProps<NodeData>) {
     return `${paramString} ${filename}`;
   };
 
+  // Calculate which options to show
+  const visibleOptions = expanded ? outputOptions : outputOptions.slice(0, 3);
+
   return (
     <Paper 
       elevation={3} 
@@ -81,11 +85,33 @@ function OutputNode({ data, id }: NodeProps<NodeData>) {
         backgroundColor: '#e3f2fd',
         border: `2px solid #2196f3`,
         color: theme.palette.text.primary,
+        position: 'relative',
       }}
     >
-      <Typography variant="h6" gutterBottom>
-        {data.label}
-      </Typography>
+      <Box sx={{ 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'flex-start',
+        mb: 1
+      }}>
+        <Typography variant="h6">
+          {data.label}
+        </Typography>
+        
+        {outputOptions.length > 3 && (
+          <Button 
+            size="small" 
+            onClick={() => setExpanded(!expanded)}
+            sx={{ 
+              minWidth: 'auto', 
+              fontSize: '0.75rem',
+              padding: '2px 8px',
+            }}
+          >
+            {expanded ? 'Less' : 'More'}
+          </Button>
+        )}
+      </Box>
       
       <Box sx={{ mt: 1 }}>
         <TextField
@@ -107,7 +133,7 @@ function OutputNode({ data, id }: NodeProps<NodeData>) {
           }}
         />
 
-        {outputOptions.map((option) => (
+        {visibleOptions.map((option) => (
           <Box key={option.name} sx={{ mt: 1 }}>
             <TextField
               fullWidth


### PR DESCRIPTION
This pull request enhances the user interface for the `FilterNode`, `GlobalNode`, `InputNode`, and `OutputNode` components in the `ffmpeg-flow-editor` by introducing collapsible options sections. This allows users to toggle between viewing a limited set of options or all available options, improving usability for nodes with a large number of configurable parameters.

### Collapsible Options Feature:

* Added a "More/Less" toggle button to the `FilterNode`, `GlobalNode`, `InputNode`, and `OutputNode` components, allowing users to expand or collapse the list of configurable options. The toggle is only displayed if there are more than three options. (`FilterNode.tsx`: [[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91R16) [[2]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91R111-R113) [[3]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L145-R181); `GlobalNode.tsx`: [[4]](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304R22) [[5]](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304R59-R61) [[6]](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304R71-R100); `InputNode.tsx`: [[7]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31R19) [[8]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31R76-R78) [[9]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31R88-R115) [[10]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31L110-R136); `OutputNode.tsx`: [[11]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccR19) [[12]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccR76-R78) [[13]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccR88-R115) [[14]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccL110-R136)

### UI Adjustments:

* Replaced the `Typography` header with a `Box` container for better layout flexibility, including space for the toggle button. (`FilterNode.tsx`: [[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L145-R181); `GlobalNode.tsx`: [[2]](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304R71-R100); `InputNode.tsx`: [[3]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31R88-R115); `OutputNode.tsx`: [[4]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccR88-R115)
* Added a `position: 'relative'` style to the `Paper` component in all nodes to ensure proper positioning of the new button. (`FilterNode.tsx`: [[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91R123); `GlobalNode.tsx`: [[2]](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304R71-R100); `InputNode.tsx`: [[3]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31R88-R115); `OutputNode.tsx`: [[4]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccR88-R115)

### Dependency Updates:

* Imported the `Button` component from `@mui/material` in all affected files to support the new toggle functionality. (`FilterNode.tsx`: [[1]](diffhunk://#diff-8462fb0d88cf3407ea414c339f24ceebf28b4c5e0f14b514ff0e7dab677b8a91L3-R3); `GlobalNode.tsx`: [[2]](diffhunk://#diff-1e7fdf93d56ece965873720a6744934af336ecb367b5f2bf14d94fbcbe3b6304L3-R3); `InputNode.tsx`: [[3]](diffhunk://#diff-644b3de0b0700f11571b61d9984471691a46666b4799c37e9989d139105c0c31L3-R3); `OutputNode.tsx`: [[4]](diffhunk://#diff-14ba683ec5459c27c82d960fd1cc8fe144dc95cb043cb7d6d3276ef9aa7325ccL3-R3)