### PR TITLE
refactor evaluateFormula 

### DIFF
--- a/ffmpeg-flow-editor/src/types/ffmpeg.ts
+++ b/ffmpeg-flow-editor/src/types/ffmpeg.ts
@@ -40,7 +40,7 @@ export interface FFMpegFilterOption {
   };
   min: string | null;
   max: string | null;
-  default: string | number | boolean | null;
+  default: string | number | boolean;
   required: boolean;
   choices: FFMpegFilterOptionChoice[];
   flags: string;

--- a/ffmpeg-flow-editor/src/utils/__tests__/__snapshots__/formulaEvaluator.test.ts.snap
+++ b/ffmpeg-flow-editor/src/utils/__tests__/__snapshots__/formulaEvaluator.test.ts.snap
@@ -2,107 +2,53 @@
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate formula with conditional inplace 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
+  "video",
+  "video",
 ]
 `;
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate formula with conditional reference 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
+  "video",
+  "video",
+  "video",
 ]
 `;
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate formula with hex conversion 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
+  "video",
+  "video",
+  "video",
 ]
 `;
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate formula with mixed audio and video 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "audio",
-  },
+  "video",
+  "video",
+  "audio",
 ]
 `;
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate formula with numeric multiplication 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
+  "video",
+  "video",
 ]
 `;
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate formula with string splitting 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
+  "video",
+  "video",
+  "video",
 ]
 `;
 
 exports[`formulaEvaluator > evaluateFormula > should evaluate simple formula with video and audio 1`] = `
 [
-  {
-    "__class__": "StreamType",
-    "value": "video",
-  },
-  {
-    "__class__": "StreamType",
-    "value": "audio",
-  },
+  "video",
+  "audio",
 ]
 `;

--- a/ffmpeg-flow-editor/src/utils/__tests__/__snapshots__/generateFFmpegCommand.test.ts.snap
+++ b/ffmpeg-flow-editor/src/utils/__tests__/__snapshots__/generateFFmpegCommand.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateFFmpegCommand > generates basic input-output-global chain 1`] = `
+{
+  "ffmpeg_cmd": "ffmpeg -i input.mp4 -map 0 output.mp4",
+  "python": "import ffmpeg
+result = ffmpeg.input('input.mp4').output(filename='output.mp4').global_args()",
+}
+`;
+
+exports[`generateFFmpegCommand > generates code with filter nodes, output and global node 1`] = `
+{
+  "ffmpeg_cmd": "ffmpeg -i input.mp4 -filter_complex '[0]scale[s0]' -map '[s0]' output.mp4",
+  "python": "import ffmpeg
+result = ffmpeg.input('input.mp4').scale().output(filename='output.mp4').global_args()",
+}
+`;
+
+exports[`generateFFmpegCommand > handles complex filter chains with outputs to global node 1`] = `
+{
+  "ffmpeg_cmd": "ffmpeg -i input.mp4 -filter_complex '[0]scale[s0];[0]volume[s1]' -map '[s0]' video_output.mp4 -map '[s1]' audio_output.mp3",
+  "python": "import ffmpeg
+input_0 = ffmpeg.input('input.mp4')
+result = ffmpeg.merge_outputs(input_0.scale().output(filename='video_output.mp4'), input_0.volume().output(filename='audio_output.mp3')).global_args()",
+}
+`;
+
+exports[`generateFFmpegCommand > handles disconnected nodes with global node 1`] = `
+{
+  "ffmpeg_cmd": undefined,
+  "python": "# Error: tuple index out of range",
+}
+`;
+
+exports[`generateFFmpegCommand > handles empty result from Python execution 1`] = `
+{
+  "ffmpeg_cmd": undefined,
+  "python": "# Error: tuple index out of range",
+}
+`;
+
+exports[`generateFFmpegCommand > handles multiple input nodes and outputs to global node 1`] = `
+{
+  "ffmpeg_cmd": "ffmpeg -i input1.mp4 -i input2.mp4 -map 0 output1.mp4 -map 1 output2.mp4",
+  "python": "import ffmpeg
+result = ffmpeg.merge_outputs(ffmpeg.input('input1.mp4').output(filename='output1.mp4'), ffmpeg.input('input2.mp4').output(filename='output2.mp4')).global_args()",
+}
+`;
+
+exports[`generateFFmpegCommand > handles numeric and boolean parameters correctly with outputs to global node 1`] = `
+{
+  "ffmpeg_cmd": "ffmpeg -i input.mp4 -filter_complex '[0]scale=width=640:height=480:force_original_aspect_ratio=1[s0]' -map '[s0]' output.mp4",
+  "python": "import ffmpeg
+result = ffmpeg.input('input.mp4').scale(width=640, height=480, force_original_aspect_ratio=True).output(filename='output.mp4').global_args()",
+}
+`;
+
+exports[`generateFFmpegCommand > returns error message if no input or output nodes 1`] = `
+{
+  "ffmpeg_cmd": undefined,
+  "python": "# Error: tuple index out of range",
+}
+`;

--- a/ffmpeg-flow-editor/src/utils/__tests__/generateFFmpegCommand.test.ts
+++ b/ffmpeg-flow-editor/src/utils/__tests__/generateFFmpegCommand.test.ts
@@ -23,13 +23,12 @@ describe('generateFFmpegCommand', () => {
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that error was logged
-    expect(result).toEqual({
-      python: '# Error: tuple index out of range',
-      ffmpeg_cmd: undefined,
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('generates basic input-output-global chain', async () => {
+    // Mock successful response from runPython
+
     const nodeMappingManager = new NodeMappingManager();
 
     // Add input node
@@ -58,14 +57,12 @@ describe('generateFFmpegCommand', () => {
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that we got the mocked response
-    expect(result).toEqual({
-      python: `import ffmpeg
-result = ffmpeg.input('input.mp4').output(filename='output.mp4').global_args()`,
-      ffmpeg_cmd: 'ffmpeg -i input.mp4 -map 0 output.mp4',
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('generates code with filter nodes, output and global node', async () => {
+    // Mock successful response from runPython
+
     const nodeMappingManager = new NodeMappingManager();
 
     // Add input node
@@ -103,11 +100,7 @@ result = ffmpeg.input('input.mp4').output(filename='output.mp4').global_args()`,
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that we got the mocked response
-    expect(result).toEqual({
-      python: `import ffmpeg
-result = ffmpeg.input('input.mp4').scale().output(filename='output.mp4').global_args()`,
-      ffmpeg_cmd: "ffmpeg -i input.mp4 -filter_complex '[0]scale[s0]' -map '[s0]' output.mp4",
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('handles multiple input nodes and outputs to global node', async () => {
@@ -150,14 +143,12 @@ result = ffmpeg.input('input.mp4').scale().output(filename='output.mp4').global_
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that we got the mocked response
-    expect(result).toEqual({
-      python: `import ffmpeg
-result = ffmpeg.merge_outputs(ffmpeg.input('input1.mp4').output(filename='output1.mp4'), ffmpeg.input('input2.mp4').output(filename='output2.mp4')).global_args()`,
-      ffmpeg_cmd: 'ffmpeg -i input1.mp4 -i input2.mp4 -map 0 output1.mp4 -map 1 output2.mp4',
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('handles complex filter chains with outputs to global node', async () => {
+    // Mock successful response from runPython
+
     const nodeMappingManager = new NodeMappingManager();
 
     // Add input node
@@ -209,16 +200,12 @@ result = ffmpeg.merge_outputs(ffmpeg.input('input1.mp4').output(filename='output
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that we got the mocked response
-    expect(result).toEqual({
-      python: `import ffmpeg
-input_0 = ffmpeg.input('input.mp4')
-result = ffmpeg.merge_outputs(input_0.scale().output(filename='video_output.mp4'), input_0.volume().output(filename='audio_output.mp3')).global_args()`,
-      ffmpeg_cmd:
-        "ffmpeg -i input.mp4 -filter_complex '[0]scale[s0];[0]volume[s1]' -map '[s0]' video_output.mp4 -map '[s1]' audio_output.mp3",
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('handles numeric and boolean parameters correctly with outputs to global node', async () => {
+    // Mock successful response from runPython
+
     const nodeMappingManager = new NodeMappingManager();
 
     // Add input node
@@ -261,12 +248,7 @@ result = ffmpeg.merge_outputs(input_0.scale().output(filename='video_output.mp4'
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that we got the mocked response
-    expect(result).toEqual({
-      python: `import ffmpeg
-result = ffmpeg.input('input.mp4').scale(width=640, height=480, force_original_aspect_ratio=True).output(filename='output.mp4').global_args()`,
-      ffmpeg_cmd:
-        "ffmpeg -i input.mp4 -filter_complex '[0]scale=width=640:height=480:force_original_aspect_ratio=1[s0]' -map '[s0]' output.mp4",
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('handles disconnected nodes with global node', async () => {
@@ -296,10 +278,7 @@ result = ffmpeg.input('input.mp4').scale(width=640, height=480, force_original_a
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that error was logged
-    expect(result).toEqual({
-      python: '# Error: tuple index out of range',
-      ffmpeg_cmd: undefined,
-    });
+    expect(result).toMatchSnapshot();
   });
 
   it('handles empty result from Python execution', async () => {
@@ -314,10 +293,7 @@ result = ffmpeg.input('input.mp4').scale(width=640, height=480, force_original_a
     const result = await generateFFmpegCommand(nodeMappingManager);
 
     // Check that a warning was logged
-    expect(result).toEqual({
-      python: '# Error: tuple index out of range',
-      ffmpeg_cmd: undefined,
-    });
+    expect(result).toMatchSnapshot();
 
     consoleWarnSpy.mockRestore();
   });

--- a/ffmpeg-flow-editor/src/utils/formulaEvaluator.ts
+++ b/ffmpeg-flow-editor/src/utils/formulaEvaluator.ts
@@ -5,12 +5,7 @@ import { StreamTypeEnum } from '../types/dag';
 export async function evaluateFormula(
   formula: string,
   parameters: Record<string, string | number | boolean>
-): Promise<
-  {
-    __class__: 'FFMpegIOType';
-    value: StreamTypeEnum;
-  }[]
-> {
+): Promise<StreamTypeEnum[]> {
   // Convert parameters to a format that can be passed to Python
   const pythonParameters = Object.entries(parameters).reduce(
     (acc, [key, value]) => {
@@ -39,10 +34,7 @@ return json.dumps(result)
 
   // Convert the result to FFmpegIOType[]
   if (Array.isArray(parsedResult)) {
-    return parsedResult.map((type) => ({
-      __class__: 'StreamType',
-      value: type as StreamTypeEnum,
-    }));
+    return parsedResult.map((type) => type as StreamTypeEnum);
   }
   console.error('Invalid result:', result);
   throw new Error('Invalid result', { cause: result });


### PR DESCRIPTION
This pull request refactors several components of the `ffmpeg-flow-editor` project to simplify data structures, improve test maintainability, and enhance snapshot testing. The key changes include removing unnecessary object wrappers in the formula evaluation logic, replacing explicit test result checks with snapshot testing, and adding new snapshot test cases for FFmpeg command generation.

### Simplification of data structures:
* Removed the `__class__` wrapper in the `evaluateFormula` function and its return type, simplifying the structure to directly return an array of `StreamTypeEnum` values. (`ffmpeg-flow-editor/src/utils/formulaEvaluator.ts`) [[1]](diffhunk://#diff-1366aa1b0f679ef564b9fdf7c16ebd34c5199795605401f5f2c07d895e23c990L8-R8) [[2]](diffhunk://#diff-1366aa1b0f679ef564b9fdf7c16ebd34c5199795605401f5f2c07d895e23c990L42-R37)

### Test improvements:
* Replaced explicit `expect` result checks with `toMatchSnapshot` in the `generateFFmpegCommand.test.ts` file, reducing verbosity and improving maintainability of test cases. (`ffmpeg-flow-editor/src/utils/__tests__/generateFFmpegCommand.test.ts`) [[1]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL26-R31) [[2]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL61-R65) [[3]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL106-R103) [[4]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL153-R151) [[5]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL212-R208) [[6]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL264-R251) [[7]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL299-R281) [[8]](diffhunk://#diff-26f2c29be9f570ef27893b74571c36eb43ebd06ed51c9d288899521a8a85d15dL317-R296)

### Snapshot additions:
* Added new snapshot test cases for `generateFFmpegCommand` to cover various scenarios, including basic chains, complex filter chains, multiple inputs, and error handling. (`ffmpeg-flow-editor/src/utils/__tests__/__snapshots__/generateFFmpegCommand.test.ts.snap`)

### Type definition changes:
* Updated the `FFMpegFilterOption` interface to remove `null` as a valid type for the `default` property, ensuring stricter type safety. (`ffmpeg-flow-editor/src/types/ffmpeg.ts`)

### Snapshot updates for formula evaluation:
* Updated snapshots for `formulaEvaluator.test.ts` to reflect the simplified return type, removing the `__class__` wrapper from the results. (`ffmpeg-flow-editor/src/utils/__tests__/__snapshots__/formulaEvaluator.test.ts.snap`)