### PR TITLE
setup github action permission

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
@@ -24,6 +26,9 @@ jobs:
         run: uv venv
       - name: Install dependencies
         run: |
+          source .venv/bin/activate
           uv pip install -r requirements.txt
       - name: Deploy documentation
-        run: uv run mkdocs gh-deploy --force
+        run: |
+          source .venv/bin/activate
+          mkdocs gh-deploy --force

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,8 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   deploy:
@@ -35,10 +36,12 @@ jobs:
         run: uv venv
       - name: Install dependencies
         run: |
+          source .venv/bin/activate
           uv pip install -r requirements.txt
       - name: Build package
         run: |
-          uv run python -m build
+          source .venv/bin/activate
+          python -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to refine permissions and ensure consistent virtual environment activation during deployment and publishing processes. The most important changes include adjustments to permissions and modifications to commands for activating the virtual environment.

### Workflow permission updates:

* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L10-R12): Changed `permissions` to grant `contents: read`, `pages: write`, and `id-token: write` for improved security and functionality during documentation deployment.
* [`.github/workflows/python-publish.yml`](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377L16-R17): Updated `permissions` to use `contents: read` and `id-token: write` for enhanced security in the Python package publishing workflow.

### Virtual environment activation:

* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R29-R34): Added `source .venv/bin/activate` to ensure the virtual environment is activated before installing dependencies and deploying documentation.
* [`.github/workflows/python-publish.yml`](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377R39-R44): Included `source .venv/bin/activate` to activate the virtual environment before installing dependencies and building the Python package.