### PR TITLE
fix #591 remove python upper version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = [
     "ffmpeg",


### PR DESCRIPTION
- fix #591 

This pull request includes a small change to the `pyproject.toml` file. The change updates the `requires-python` field to remove the upper version limit, allowing compatibility with Python versions beyond 4.0.