### PR TITLE
fix #606 support parse ffmpeg.exe

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -356,7 +356,7 @@ def parse(cli: str) -> Stream:
     ffmpeg_filters = get_filter_dict()
 
     tokens = shlex.split(cli)
-    assert tokens[0] == "ffmpeg"
+    assert tokens[0].lower().split(".")[0] == "ffmpeg"
     tokens = tokens[1:]
 
     # Parse global options first

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_exe[parse-ffmpeg-exe].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_exe[parse-ffmpeg-exe].json
@@ -1,0 +1,1 @@
+"GlobalStream(node=GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None),), filename='output_video.mp4'), index=None),)), index=None)"

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -23,3 +23,11 @@ def test_parse_compile(snapshot: SnapshotAssertion, graph: Stream) -> None:
         compiled,
         compiled_again,
     )
+
+
+def test_parse_ffmpeg_exe(snapshot: SnapshotAssertion) -> None:
+    parsed = parse("ffmpeg.exe -i input_video.mkv output_video.mp4")
+    assert (
+        snapshot(name="parse-ffmpeg-exe", extension_class=JSONSnapshotExtension)
+        == parsed
+    )


### PR DESCRIPTION
- fix #606

This pull request includes updates to the `parse` function in `compile_cli.py` to improve compatibility with different `ffmpeg` executable names, adds a new test case for parsing `ffmpeg.exe` commands, and updates the test snapshots accordingly.

### Functionality Enhancements:

* [`src/ffmpeg/compile/compile_cli.py`](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L359-R359): Updated the `parse` function to handle variations in `ffmpeg` executable names by converting the first token to lowercase and splitting it on the period before asserting it equals `"ffmpeg"`.

### Testing Improvements:

* [`src/ffmpeg/compile/tests/test_compile_cli.py`](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R26-R33): Added a new test case `test_parse_ffmpeg_exe` to validate the parsing of commands using `ffmpeg.exe`. This ensures compatibility with Windows-style executable names.
* `src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_exe[parse-ffmpeg-exe].json`: Added a new snapshot for the `test_parse_ffmpeg_exe` test case, capturing the parsed graph structure for the given command. ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_exe[parse-ffmpeg-exe].jsonR1](diffhunk://#diff-c869f715de2b2ddbbf7a9cf86ab758fa185ce35cc43c988ff37a5b8ef476c5e7R1))