### PR TITLE
fix #609 handle global binary option

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -326,7 +326,7 @@ def parse_global(
         option = ffmpeg_options[key]
 
         if option.is_global_option:
-            # just ignore not input options
+            # Process only recognized global options
             if value[-1] is None:
                 parameters[key] = True
             else:

--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -340,7 +340,7 @@ def parse(cli: str) -> Stream:
     ffmpeg_filters = get_filter_dict()
 
     tokens = shlex.split(cli)
-    assert tokens[0] == "ffmpeg"
+    assert tokens[0].lower().split(".")[0] == "ffmpeg"
     tokens = tokens[1:]
 
     # Parse global options first

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_exe[parse-ffmpeg-exe].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_exe[parse-ffmpeg-exe].json
@@ -1,0 +1,1 @@
+"GlobalStream(node=GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None),), filename='output_video.mp4'), index=None),)), index=None)"

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_global_binary_option[parse-global-binary-option].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_global_binary_option[parse-global-binary-option].json
@@ -1,0 +1,1 @@
+"GlobalStream(node=GlobalNode(kwargs=FrozenDict({'stdin': False}), inputs=()), index=None)"

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -23,3 +23,13 @@ def test_parse_compile(snapshot: SnapshotAssertion, graph: Stream) -> None:
         compiled,
         compiled_again,
     )
+
+
+def test_parse_global_binary_option(snapshot: SnapshotAssertion) -> None:
+    parsed = parse("ffmpeg -nostdin -i input_video.mkv -y output_video.mp4")
+    assert (
+        snapshot(
+            name="parse-global-binary-option", extension_class=JSONSnapshotExtension
+        )
+        == parsed
+    )

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -33,3 +33,11 @@ def test_parse_global_binary_option(snapshot: SnapshotAssertion) -> None:
         )
         == parsed
     )
+
+
+def test_parse_ffmpeg_exe(snapshot: SnapshotAssertion) -> None:
+    parsed = parse("ffmpeg.exe -i input_video.mkv output_video.mp4")
+    assert (
+        snapshot(name="parse-ffmpeg-exe", extension_class=JSONSnapshotExtension)
+        == parsed
+    )


### PR DESCRIPTION
- fix: #609

This pull request refactors the `parse_global` function in `src/ffmpeg/compile/compile_cli.py` to simplify the parsing logic and adds a new test case for binary options. The most important changes include the introduction of the `parse_options` helper function, updates to the global parameters parsing logic, and the addition of snapshot testing for binary options.

### Refactoring of `parse_global` function:
* Simplified the parsing logic by introducing the `parse_options` helper function to handle token slicing and option parsing. This reduces redundancy and improves readability. (`src/ffmpeg/compile/compile_cli.py`, [src/ffmpeg/compile/compile_cli.pyL320-R334](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L320-R334))

### Addition of snapshot testing:
* Added a new test case `test_parse_global_binary_option` to verify the handling of binary options (`-nostdin`) and ensure consistent parsing behavior. (`src/ffmpeg/compile/tests/test_compile_cli.py`, [src/ffmpeg/compile/tests/test_compile_cli.pyR26-R35](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R26-R35))
* Updated snapshot file to include the expected output for the new binary option test. (`src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_global_binary_option[parse-global-binary-option].json`, [src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_global_binary_option[parse-global-binary-option].jsonR1](diffhunk://#diff-28007f8d137bfe8edd0e7c63d082208230d33d010b32227a63f6e25533a18fb4R1))