### PR TITLE
fix #617 coverage report

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest src --cov=ffmpeg --cov-report=xml
+          pytest src --cov=./src --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
- fix #617

This pull request makes a small adjustment to the test command in the CI workflow configuration file to ensure the correct coverage path is specified.

* [`.github/workflows/ci-package.yml`](diffhunk://#diff-6a20f4e4b19664a42290918f5d45a4bb26d62773a1b68af4e3097201d3543885L48-R48): Updated the `pytest` command to use `--cov=./src` instead of `--cov=ffmpeg` for accurate coverage reporting.