### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/livingbio/typed-ffmpeg/security/code-scanning/2](https://github.com/livingbio/typed-ffmpeg/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
- The `contents: read` permission is sufficient for most steps, such as checking out the repository and running tests.
- The `contents: write` permission is not required as the workflow does not modify repository contents.
- The `id-token: write` permission is not needed since there is no OpenID Connect (OIDC) token usage.
- The `statuses: write` permission is not required as there are no steps that update commit statuses.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
