### PR TITLE
fix #622 improve ci

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -3,8 +3,12 @@ name: CI Scripts
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
 
 jobs:
   build:

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,65 +1,58 @@
-name: CI Package
+name: CI Scripts
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'src/ffmpeg/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'src/ffmpeg/**'
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.10'
 
       - name: Install GCC and ffmpeg
         run: sudo apt-get update && sudo apt-get install -y build-essential nasm ffmpeg && ffmpeg -version
+
       - name: Install uv
         run: pip install uv
+
       - name: Create virtual environment
         run: uv venv
+
       - name: Install dependencies
         run: |
           source .venv/bin/activate
           uv pip install -r requirements.txt
-      - name: Build package
-        run: |
-          source .venv/bin/activate
-          python -m build
-      - name: Install package
-        run: |
-          source .venv/bin/activate
-          pip install dist/*.whl
+
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest src/ffmpeg --cov=./src/ffmpeg --cov-report=xml
+          pytest src/scripts --cov=./src/scripts --cov-report=xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
-          flags: backend,python,${{ matrix.python-version }}
-          name: backend-coverage-py${{ matrix.python-version }}
+          flags: scripts,python-3.10
+          name: scripts-coverage
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+      - name: Build Mkdocs
+        run: |
+          source .venv/bin/activate
+          mkdocs build
 
       # Run linting
       - name: Linting
         run: uv run pre-commit run --all-files
-        working-directory: src/ffmpeg
+        working-directory: src/scripts

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,5 +1,8 @@
 name: CI Scripts
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
- fix #622

This pull request introduces updates to the CI workflows to better handle testing, coverage, and linting for specific subdirectories (`src/ffmpeg` and `src/scripts`). It also adds a new workflow for scripts-related tasks.

### Updates to CI workflows:

* [`.github/workflows/ci-package.yml`](diffhunk://#diff-6a20f4e4b19664a42290918f5d45a4bb26d62773a1b68af4e3097201d3543885R6-R11): Modified the paths for triggering the workflow to include `src/ffmpeg/**`, updated the test and linting commands to target the `src/ffmpeg` directory, and removed Mkdocs build steps. [[1]](diffhunk://#diff-6a20f4e4b19664a42290918f5d45a4bb26d62773a1b68af4e3097201d3543885R6-R11) [[2]](diffhunk://#diff-6a20f4e4b19664a42290918f5d45a4bb26d62773a1b68af4e3097201d3543885L48-R52) [[3]](diffhunk://#diff-6a20f4e4b19664a42290918f5d45a4bb26d62773a1b68af4e3097201d3543885L58-R65)

### Addition of a new CI workflow:

* [`.github/workflows/ci-scripts.yml`](diffhunk://#diff-cac9e2a290129c8a653160b69c838a610731b09862dad67873565d59fa7f1c04R1-R58): Added a new workflow for scripts-related tasks, including setup steps (Python 3.10, GCC, ffmpeg), dependency installation, running tests for `src/scripts`, uploading coverage to Codecov, building Mkdocs, and linting.