### PR TITLE
fix #614 improve output option handling

### DIFF
--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
@@ -11,6 +11,12 @@
 # name: test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands]
   GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None),), filename='output_video.mp4'), index=None),)), index=None)
 # ---
+# name: test_parse_ffmpeg_commands[output_option_with_boolean_option][build-ffmpeg-commands]
+  'ffmpeg -y -nostdin -i input_video.mkv -shortest -b:v 1000k -b:a 128k output_video.mp4'
+# ---
+# name: test_parse_ffmpeg_commands[output_option_with_boolean_option][parse-ffmpeg-commands]
+  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({'shortest': True, 'b:v': '1000k', 'b:a': '128k'}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None),), filename='output_video.mp4'), index=None),)), index=None)
+# ---
 # name: test_parse_ffmpeg_commands[output_option_with_stream_selector][build-ffmpeg-commands]
   'ffmpeg -y -nostdin -i input_video.mkv -b:v 1000k output_video.mp4'
 # ---

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -40,6 +40,10 @@ def test_parse_compile(snapshot: SnapshotAssertion, graph: Stream) -> None:
             "ffmpeg -y -nostdin -i input_video.mkv -b:v 1000k output_video.mp4",
             id="output_option_with_stream_selector",
         ),
+        pytest.param(
+            "ffmpeg -y -nostdin -i input_video.mkv -shortest -b:v 1000k -b:a 128k output_video.mp4",
+            id="output_option_with_boolean_option",
+        ),
     ],
 )
 def test_parse_ffmpeg_commands(snapshot: SnapshotAssertion, command: str) -> None:


### PR DESCRIPTION
- fix #614 

Before this PR, the parse_output function relied on checking whether an argument was not - and whether it followed an option to determine if it was an output filename. However, this approach breaks when encountering boolean flags like -shortest, which don’t take values. As a result, it failed to correctly parse commands such as:

ffmpeg -y -nostdin -i input_video.mkv -shortest -b:v 1000k -b:a 128k output_video.mp4

In this PR, we switch to using file extensions to help identify output filenames.
While this method isn’t 100% accurate, it’s a clear improvement over the previous heuristic.

This pull request enhances the `src/ffmpeg/compile/compile_cli.py` module by adding detailed docstrings to improve code readability and maintainability. It also updates the test suite to cover new cases related to FFmpeg command parsing and output options.

### Documentation Improvements:
* Added comprehensive docstrings to functions such as `get_options_dict`, `get_filter_dict`, `parse_stream_selector`, `parse_output`, `parse_input`, and `parse` to describe their purpose, arguments, return values, and examples. These docstrings clarify the functionality of each method and improve developer understanding. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R50-R66) [[2]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R114-R131) [[3]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R159-R200) [[4]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R245-R257) [[5]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R422-R444)

### Test Suite Enhancements:
* Updated `test_compile_cli.py` and its snapshot file to include new test cases for FFmpeg commands with boolean output options, ensuring correct handling of these scenarios. This improves the robustness of the test suite. [[1]](diffhunk://#diff-265a46bda407bf72dbb55e79acd2df83a62beae66bc413a36fdbe4323e8256bbR14-R19) [[2]](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R43-R46)