### PR TITLE
fix #629 ignore not recognized option

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -223,15 +223,15 @@ def parse_output(
         parameters: dict[str, str | bool] = {}
 
         for key, value in options.items():
-            assert key.split(":")[0] in ffmpeg_options, f"Unknown option: {key}"
-            option = ffmpeg_options[key.split(":")[0]]
+            if key.split(":")[0] in ffmpeg_options:
+                option = ffmpeg_options[key.split(":")[0]]
 
-            if option.is_output_option:
-                # just ignore not input options
-                if value[-1] is None:
-                    parameters[key] = True
-                else:
-                    parameters[key] = value[-1]
+                if option.is_output_option:
+                    # just ignore not input options
+                    if value[-1] is None:
+                        parameters[key] = True
+                    else:
+                        parameters[key] = value[-1]
 
         export.append(output(*inputs, filename=filename, extra_options=parameters))
         buffer = []
@@ -268,15 +268,15 @@ def parse_input(
         parameters: dict[str, str | bool] = {}
 
         for key, value in options.items():
-            assert key in ffmpeg_options, f"Unknown option: {key}"
-            option = ffmpeg_options[key]
+            if key in ffmpeg_options:
+                option = ffmpeg_options[key]
 
-            if option.is_input_option:
-                # just ignore not input options
-                if value[-1] is None:
-                    parameters[key] = True
-                else:
-                    parameters[key] = value[-1]
+                if option.is_input_option:
+                    # just ignore not input options
+                    if value[-1] is None:
+                        parameters[key] = True
+                    else:
+                        parameters[key] = value[-1]
 
         output.append(input(filename=filename, extra_options=parameters))
 
@@ -406,15 +406,15 @@ def parse_global(
     parameters: dict[str, str | bool] = {}
 
     for key, value in options.items():
-        assert key in ffmpeg_options, f"Unknown option: {key}"
-        option = ffmpeg_options[key]
+        if key in ffmpeg_options:
+            option = ffmpeg_options[key]
 
-        if option.is_global_option:
-            # Process only recognized global options
-            if value[-1] is None:
-                parameters[key] = True
-            else:
-                parameters[key] = value[-1]
+            if option.is_global_option:
+                # Process only recognized global options
+                if value[-1] is None:
+                    parameters[key] = True
+                else:
+                    parameters[key] = value[-1]
     return parameters, remaining_tokens
 
 

--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -223,8 +223,9 @@ def parse_output(
         parameters: dict[str, str | bool] = {}
 
         for key, value in options.items():
-            if key.split(":")[0] in ffmpeg_options:
-                option = ffmpeg_options[key.split(":")[0]]
+            key_base = key.split(":")[0]
+            if key_base in ffmpeg_options:
+                option = ffmpeg_options[key_base]
 
                 if option.is_output_option:
                     # just ignore not input options

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
@@ -11,6 +11,12 @@
 # name: test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands]
   GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None),), filename='output_video.mp4'), index=None),)), index=None)
 # ---
+# name: test_parse_ffmpeg_commands[ignore_not_exist_option][build-ffmpeg-commands]
+  'ffmpeg -y -nostdin -b:v 1000k -b:a 128k output_video.mp4'
+# ---
+# name: test_parse_ffmpeg_commands[ignore_not_exist_option][parse-ffmpeg-commands]
+  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({'b:v': '1000k', 'b:a': '128k'}), inputs=(), filename='output_video.mp4'), index=None),)), index=None)
+# ---
 # name: test_parse_ffmpeg_commands[output_option_with_boolean_option][build-ffmpeg-commands]
   'ffmpeg -y -nostdin -i input_video.mkv -shortest -b:v 1000k -b:a 128k output_video.mp4'
 # ---

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -44,6 +44,10 @@ def test_parse_compile(snapshot: SnapshotAssertion, graph: Stream) -> None:
             "ffmpeg -y -nostdin -i input_video.mkv -shortest -b:v 1000k -b:a 128k output_video.mp4",
             id="output_option_with_boolean_option",
         ),
+        pytest.param(
+            "ffmpeg -y -not-exist-global -nostdin -i input_video.mkv -not-exist-input -i input-2.mp4 -not-exist-output -b:v 1000k -b:a 128k output_video.mp4",
+            id="ignore_not_exist_option",
+        ),
     ],
 )
 def test_parse_ffmpeg_commands(snapshot: SnapshotAssertion, command: str) -> None:


### PR DESCRIPTION
- fix #629

This pull request modifies the behavior of the `parse_*` functions in `compile_cli.py` to handle unknown options more gracefully by replacing assertions with conditional checks. It also updates the test suite to validate this new behavior by adding test cases for ignoring non-existent options.

### Changes to option handling:

* [`src/ffmpeg/compile/compile_cli.py`](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L226-R226): Replaced `assert` statements with conditional checks in the `parse_output`, `parse_input`, and `parse_global` functions to ensure unknown options are ignored instead of raising an assertion error. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L226-R226) [[2]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L271-R271) [[3]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L409-R409)

### Updates to test coverage:

* [`src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr`](diffhunk://#diff-265a46bda407bf72dbb55e79acd2df83a62beae66bc413a36fdbe4323e8256bbR14-R19): Added snapshot tests for commands with non-existent options to verify they are ignored during parsing.
* [`src/ffmpeg/compile/tests/test_compile_cli.py`](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R47-R50): Introduced a new test case, `ignore_not_exist_option`, to test the handling of non-existent options in `parse_ffmpeg_commands`.