### PR TITLE
fix #631 parse drawtext with special character

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -309,7 +309,8 @@ def parse_filter_complex(
     Returns:
         Updated stream mapping with new filter outputs added
     """
-    filter_units = filter_complex.split(";")
+    # Use re.split with negative lookbehind to handle escaped semicolons
+    filter_units = re.split(r"(?<!\\);", filter_complex)
 
     for filter_unit in filter_units:
         pattern = re.compile(
@@ -335,11 +336,12 @@ def parse_filter_complex(
 
         # Parse filter parameters into key-value pairs
         filter_params = {}
+        param_str = param_str and param_str.strip()
         if param_str:
-            param_parts = param_str.strip().split(":")
+            param_parts = re.split(r"(?<!\\)\:", param_str)
             for part in param_parts:
                 if "=" in part:
-                    key, value = part.split("=", 1)
+                    key, value = re.split(r"(?<!\\)=", part, 1)
                     filter_params[key.strip()] = value.strip()
 
         assert isinstance(filter_name, str), f"Expected filter name, got {filter_name}"

--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -338,7 +338,7 @@ def parse_filter_complex(
         filter_params = {}
         param_str = param_str and param_str.strip()
         if param_str:
-            param_parts = re.split(r"(?<!\\)\:", param_str)
+            param_parts = re.split(r"(?<!\\):", param_str)
             for part in param_parts:
                 if "=" in part:
                     key, value = re.split(r"(?<!\\)=", part, 1)

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
@@ -1,4 +1,10 @@
 # serializer version: 1
+# name: test_parse_ffmpeg_commands[escaping][build-ffmpeg-commands]
+  'ffmpeg -i input.mov -filter_complex \'[0:v]drawtext=fontfile=resources/fonts/arial.ttf:text=\\\\\\\'"\'"\'\\\\=\\\\\\\\\\;\\\\\\\\\\\\:\\\\\\\'"\'"\':fontcolor=white:fontsize=30:x=(W-tw)/2:y=text_h:borderw=2:timecode=00\\\\\\\\\\\\:00\\\\\\\\\\\\:00\\\\\\\\\\\\:00:r=25/1[s0]\' -map \'[s0]\' output.mp4'
+# ---
+# name: test_parse_ffmpeg_commands[escaping][parse-ffmpeg-commands]
+  GlobalStream(node=GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(VideoStream(node=FilterNode(kwargs=FrozenDict({'fontfile': 'resources/fonts/arial.ttf', 'text': "'=\\;\\:'", 'fontcolor': 'white', 'fontsize': '30', 'x': '(W-tw)/2', 'y': 'text_h', 'borderw': '2', 'timecode': '00\\:00\\:00\\:00', 'r': '25/1'}), inputs=(VideoStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input.mov'), index=None),), name='drawtext', input_typings=(<StreamType.video: 'video'>,), output_typings=(<StreamType.video: 'video'>,)), index=0),), filename='output.mp4'), index=None),)), index=None)
+# ---
 # name: test_parse_ffmpeg_commands[ffmpeg_exe][build-ffmpeg-commands]
   'ffmpeg -i input_video.mkv output_video.mp4'
 # ---

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -48,6 +48,10 @@ def test_parse_compile(snapshot: SnapshotAssertion, graph: Stream) -> None:
             "ffmpeg -y -not-exist-global -nostdin -i input_video.mkv -not-exist-input -i input-2.mp4 -not-exist-output -b:v 1000k -b:a 128k output_video.mp4",
             id="ignore_not_exist_option",
         ),
+        pytest.param(
+            """ffmpeg -i input.mov -filter_complex "[0:v]drawtext=text='=\\\\;\\:':borderw=2:fontcolor=white:fontfile=resources/fonts/arial.ttf:fontsize=30:r=25/1:timecode=00\\:00\\:00\\:00:x=(W-tw)/2:y=text_h[out]" -map [out] output.mp4""",
+            id="escaping",
+        ),
     ],
 )
 def test_parse_ffmpeg_commands(snapshot: SnapshotAssertion, command: str) -> None:


### PR DESCRIPTION
- fix #631 
This pull request enhances the handling of escaped characters in FFmpeg command parsing and adds corresponding test cases to ensure robustness. The most important changes include updates to parsing logic in `compile_cli.py` and new test cases in `test_compile_cli.py` to validate the changes.

### Parsing Logic Enhancements:
* [`src/ffmpeg/compile/compile_cli.py`](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L312-R313): Updated `parse_filter_complex` to use `re.split` with negative lookbehind for handling escaped semicolons in FFmpeg filter strings. Similarly, updated parameter parsing in `extract_labels` to handle escaped colons and equal signs. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192L312-R313) [[2]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R339-R344)

### Testing Additions:
* [`src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr`](diffhunk://#diff-265a46bda407bf72dbb55e79acd2df83a62beae66bc413a36fdbe4323e8256bbR2-R7): Added snapshot tests for scenarios involving escaped characters in FFmpeg commands.
* [`src/ffmpeg/compile/tests/test_compile_cli.py`](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R51-R54): Introduced a new test case (`escaping`) to validate parsing of FFmpeg commands with escaped characters.