### PR TITLE
refactor compile cli

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -141,32 +141,24 @@ def parse_stream_selector(
     stream = mapping[stream_label]
 
     if isinstance(stream, AVStream):
-        if selector.count(":") == 1:
-            stream_label, stream_type = selector.split(":", 1)
+        if ":" in selector:
+            if selector.count(":") == 1:
+                stream_label, stream_type = selector.split(":", 1)
+                stream_index = None
+            elif selector.count(":") == 2:
+                stream_label, stream_type, _stream_index = selector.split(":", 2)
+                stream_index = int(_stream_index)
+
             match stream_type:
                 case "v":
-                    return stream.video
+                    return stream.video_stream(stream_index)
                 case "a":
-                    return stream.audio
+                    return stream.audio_stream(stream_index)
                 case "s":
-                    return stream.subtitle
+                    return stream.subtitle_stream(stream_index)
                 case _:
                     raise FFMpegValueError(f"Unknown stream type: {stream_type}")
-        elif selector.count(":") == 2:
-            stream_label, stream_type, stream_index = selector.split(":", 2)
-            match stream_type:
-                case "v":
-                    return stream.video_stream(int(stream_index))
-                case "a":
-                    return stream.audio_stream(int(stream_index))
-                case "s":
-                    return stream.subtitle_stream(int(stream_index))
-                case _:
-                    raise FFMpegValueError(f"Unknown stream type: {stream_type}")
-        else:
-            return stream
-    else:
-        return stream
+    return stream
 
 
 def _is_filename(token: str) -> bool:

--- a/src/ffmpeg/streams/av.py
+++ b/src/ffmpeg/streams/av.py
@@ -41,7 +41,7 @@ class AVStream(AudioStream, VideoStream):
         """
         return SubtitleStream(node=self.node, index=self.index)
 
-    def video_stream(self, index: int) -> VideoStream:
+    def video_stream(self, index: int | None = None) -> VideoStream:
         """
         Get the video stream from the input node with a specified index.
 
@@ -53,7 +53,7 @@ class AVStream(AudioStream, VideoStream):
         """
         return VideoStream(node=self.node, index=index)
 
-    def audio_stream(self, index: int) -> AudioStream:
+    def audio_stream(self, index: int | None = None) -> AudioStream:
         """
         Get the audio stream from the input node with a specified index.
 
@@ -65,7 +65,7 @@ class AVStream(AudioStream, VideoStream):
         """
         return AudioStream(node=self.node, index=index)
 
-    def subtitle_stream(self, index: int) -> SubtitleStream:
+    def subtitle_stream(self, index: int | None = None) -> SubtitleStream:
         """
         Get the subtitle stream from the input node with a specified index.
 


### PR DESCRIPTION
This pull request refactors stream selection in the FFmpeg module to improve flexibility and handle optional stream indices. The changes primarily focus on modifying stream-related methods and the stream selector parsing logic.

### Stream selection refactoring:

* [`src/ffmpeg/compile/compile_cli.py`](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R144-L168): Updated the `parse_stream_selector` function to handle cases where the stream index is optional. The logic now supports selectors with or without a specified index and ensures proper parsing of stream labels, types, and indices.

* [`src/ffmpeg/streams/av.py`](diffhunk://#diff-997903821e31da91eed208941ae560dad6772fff0c353ab00516f80e8e8c88cfL44-R44): Modified the `video_stream`, `audio_stream`, and `subtitle_stream` methods to accept an optional `index` parameter (`int | None`). This change ensures compatibility with the updated selector parsing logic and allows for more flexible stream handling. [[1]](diffhunk://#diff-997903821e31da91eed208941ae560dad6772fff0c353ab00516f80e8e8c88cfL44-R44) [[2]](diffhunk://#diff-997903821e31da91eed208941ae560dad6772fff0c353ab00516f80e8e8c88cfL56-R56) [[3]](diffhunk://#diff-997903821e31da91eed208941ae560dad6772fff0c353ab00516f80e8e8c88cfL68-R68)