### PR TITLE
fix #646 export subtitle stream

### DIFF
--- a/src/ffmpeg/__init__.py
+++ b/src/ffmpeg/__init__.py
@@ -28,7 +28,7 @@ from .dag import Stream
 from .exceptions import FFMpegExecuteError, FFMpegTypeError, FFMpegValueError
 from .ffprobe.probe import probe, probe_obj
 from .info import get_codecs, get_decoders, get_encoders
-from .streams import AudioStream, AVStream, VideoStream
+from .streams import AudioStream, AVStream, SubtitleStream, VideoStream
 
 __all__ = [
     "sources",
@@ -46,6 +46,7 @@ __all__ = [
     "AudioStream",
     "VideoStream",
     "AVStream",
+    "SubtitleStream",
     "vfilter",
     "afilter",
     "filter_multi_output",

--- a/src/ffmpeg/streams/__init__.py
+++ b/src/ffmpeg/streams/__init__.py
@@ -1,5 +1,6 @@
 from .audio import AudioStream
 from .av import AVStream
+from .subtitle import SubtitleStream
 from .video import VideoStream
 
-__all__ = ["AudioStream", "VideoStream", "AVStream"]
+__all__ = ["AudioStream", "VideoStream", "AVStream", "SubtitleStream"]

--- a/src/ffmpeg/tests/__snapshots__/test_ffmpeg/test_typed_ffmpeg.json
+++ b/src/ffmpeg/tests/__snapshots__/test_ffmpeg/test_typed_ffmpeg.json
@@ -5,6 +5,7 @@
   "FFMpegTypeError",
   "FFMpegValueError",
   "Stream",
+  "SubtitleStream",
   "VideoStream",
   "__all__",
   "__builtins__",


### PR DESCRIPTION
- fix #646

This pull request introduces support for `SubtitleStream` in the `ffmpeg` module by integrating it into the existing stream handling framework. The changes ensure that `SubtitleStream` is properly imported, exported, and tested across the module.

### Integration of `SubtitleStream`:

* [`src/ffmpeg/__init__.py`](diffhunk://#diff-c2f708cb17a1faed88f3f1acff4f0766e32d57dec5dadaed66863371d293ab76L31-R31): Added `SubtitleStream` to the list of imported streams and updated the `__all__` export list to include it. [[1]](diffhunk://#diff-c2f708cb17a1faed88f3f1acff4f0766e32d57dec5dadaed66863371d293ab76L31-R31) [[2]](diffhunk://#diff-c2f708cb17a1faed88f3f1acff4f0766e32d57dec5dadaed66863371d293ab76R49)
* [`src/ffmpeg/streams/__init__.py`](diffhunk://#diff-3d97813f3dfb26b54d8126dea7aa28796ea6516237e5f35b46d5600b86e7c9a4R3-R6): Imported `SubtitleStream` from its module and updated the `__all__` export list to include it.

### Testing updates:

* [`src/ffmpeg/tests/__snapshots__/test_ffmpeg/test_typed_ffmpeg.json`](diffhunk://#diff-1db6666f9cbd530a48b6c8c8374567164c07ae38bcc4d320593b0591dd31b559R8): Added `SubtitleStream` to the snapshot test data to ensure its inclusion is validated during testing.