### PR TITLE
fix #700 allow str

### DIFF
--- a/src/ffmpeg/types.py
+++ b/src/ffmpeg/types.py
@@ -49,25 +49,25 @@ Pix_fmt = str | Default | LazyValue
 please see `ffmpeg -pix_fmts` for a list of supported pixel formats.
 """
 
-Int = int | Default | LazyValue
+Int = str | int | Default | LazyValue
 """
 This represents FFmpeg's integer type. It can accept either a Python integer value
 or a string that represents a integer value.
 """
 
-Int64 = int | Default | LazyValue
+Int64 = str | int | Default | LazyValue
 """
 This represents FFmpeg's integer type. It can accept either a Python integer value
 or a string that represents a integer value.
 """
 
-Double = int | float | Default | LazyValue
+Double = str | int | float | Default | LazyValue
 """
 This represents FFmpeg's double type. It can accept either a Python integer or float value
 or a string that represents a double value.
 """
 # TODO: more info
-Float = int | float | Default | LazyValue
+Float = str | int | float | Default | LazyValue
 """
 This represents FFmpeg's float type. It can accept either a Python integer or float value
 or a string that represents a float value.


### PR DESCRIPTION
- fix #700 

This pull request updates type definitions in `src/ffmpeg/types.py` to expand the accepted input types for FFmpeg's numeric types. The changes ensure that string representations of numeric values are now supported alongside existing types.

Updates to type definitions:

* `Int`, `Int64`, `Double`, and `Float` types were updated to include `str` as an accepted type, allowing string representations of numeric values.
