### PR TITLE
fix #702, allow None

### DIFF
--- a/src/ffmpeg/types.py
+++ b/src/ffmpeg/types.py
@@ -9,14 +9,14 @@ from typing import Literal
 from .schema import Default
 from .utils.lazy_eval.schema import LazyValue
 
-Boolean = bool | Literal["true", "false", "1", "0"] | Default | LazyValue
+Boolean = bool | Literal["true", "false", "1", "0"] | Default | LazyValue | None
 """
 This represents FFmpeg's boolean type. It can accept either a Python boolean value (`True` or `False`)
 or a string that represents a boolean value ("true", "false", "1", or "0").
 
 """
 
-Duration = str | int | float | Default | LazyValue
+Duration = str | int | float | Default | LazyValue | None
 """
 This represents FFmpeg's duration type. It can accept either a Python integer or float value
 or a string that represents a duration value.
@@ -25,7 +25,7 @@ Note:
     [Document](https://ffmpeg.org/ffmpeg-utils.html#Time-duration)
 """
 
-Color = str | Default | LazyValue
+Color = str | Default | LazyValue | None
 """
 It can be the name of a color as defined below (case insensitive match) or a [0x|#]RRGGBB[AA] sequence, possibly followed by @ and a string representing the alpha component.
 The alpha component may be a string composed by "0x" followed by an hexadecimal number or a decimal number between 0.0 and 1.0, which represents the opacity value (‘0x00’ or ‘0.0’ means completely transparent, ‘0xff’ or ‘1.0’ completely opaque). If the alpha component is not specified then ‘0xff’ is assumed.
@@ -35,50 +35,50 @@ Note:
     [Document](https://ffmpeg.org/ffmpeg-utils.html#Color)
 """
 
-Flags = str | Default | LazyValue
+Flags = str | Default | LazyValue | None
 """
 This represents FFmpeg's flags type. It accepts a string in the format "A+B",
 where "A" and "B" are individual flags. For example, "fast+bilinear" would
 represent two flags, "fast" and "bilinear", to be used in FFmpeg's command line.
 """
 
-Dictionary = str | Default | LazyValue
+Dictionary = str | Default | LazyValue | None
 # format A=B:C=D:E=F
-Pix_fmt = str | Default | LazyValue
+Pix_fmt = str | Default | LazyValue | None
 """
 please see `ffmpeg -pix_fmts` for a list of supported pixel formats.
 """
 
-Int = str | int | Default | LazyValue
+Int = str | int | Default | LazyValue | None
 """
 This represents FFmpeg's integer type. It can accept either a Python integer value
 or a string that represents a integer value.
 """
 
-Int64 = str | int | Default | LazyValue
+Int64 = str | int | Default | LazyValue | None
 """
 This represents FFmpeg's integer type. It can accept either a Python integer value
 or a string that represents a integer value.
 """
 
-Double = str | int | float | Default | LazyValue
+Double = str | int | float | Default | LazyValue | None
 """
 This represents FFmpeg's double type. It can accept either a Python integer or float value
 or a string that represents a double value.
 """
 # TODO: more info
-Float = str | int | float | Default | LazyValue
+Float = str | int | float | Default | LazyValue | None
 """
 This represents FFmpeg's float type. It can accept either a Python integer or float value
 or a string that represents a float value.
 """
-String = str | int | float | Default | LazyValue
+String = str | int | float | Default | LazyValue | None
 """
 This represents FFmpeg's string type. It can accept either a Python string value
 or a int/float that will be converted to a string.
 """
 
-Video_rate = str | int | float | Default | LazyValue
+Video_rate = str | int | float | Default | LazyValue | None
 """
 Specify the frame rate of a video, expressed as the number of frames generated per second. It has to be a string in the format frame_rate_num/frame_rate_den, an integer number, a float number or a valid video frame rate abbreviation.
 
@@ -87,7 +87,7 @@ Note:
 """
 
 # TODO: enum
-Image_size = str | Default | LazyValue
+Image_size = str | Default | LazyValue | None
 """
 Specify the size of the sourced video, it may be a string of the form widthxheight, or the name of a size abbreviation.
 
@@ -95,7 +95,7 @@ Note:
     [Document](https://ffmpeg.org/ffmpeg-utils.html#Video-size)
 """
 
-Rational = str | Default | LazyValue
+Rational = str | Default | LazyValue | None
 """
 Specify the frame rate of a video, expressed as the number of frames generated per second. It has to be a string in the format frame_rate_num/frame_rate_den, an integer number, a float number or a valid video frame rate abbreviation.
 
@@ -104,16 +104,16 @@ Note:
 """
 
 
-Sample_fmt = str | Default | LazyValue
-Binary = str | Default | LazyValue
+Sample_fmt = str | Default | LazyValue | None
+Binary = str | Default | LazyValue | None
 
 # OPT Type
-Func = str | int | float | Default | LazyValue
+Func = str | int | float | Default | LazyValue | None
 """
 ref: OPT_TYPE_FUNC
 """
 
-Time = str | int | float | Default | LazyValue
+Time = str | int | float | Default | LazyValue | None
 """
 ref: OPT_TYPE_TIME
 """


### PR DESCRIPTION
- fix #702 
- mypy won't complain the original case, so I guess this PR is more for pyright 


This pull request updates the type definitions in `src/ffmpeg/types.py` to allow `None` as a valid value for various FFmpeg-related types. This change improves flexibility by accommodating scenarios where a type might not have a value explicitly set.

### Updates to Type Definitions:

* **Boolean, Duration, Color, Flags, Dictionary, Pix_fmt, Int, Int64, Double, Float, String, Video_rate**: Added `None` as a valid type option to support cases where these values might be unset. [[1]](diffhunk://#diff-9769530dc9b73d777a0abe7a869f0b2b7992aadc04cfe667d0ba35ae195a00ccL12-R19) [[2]](diffhunk://#diff-9769530dc9b73d777a0abe7a869f0b2b7992aadc04cfe667d0ba35ae195a00ccL28-R28) [[3]](diffhunk://#diff-9769530dc9b73d777a0abe7a869f0b2b7992aadc04cfe667d0ba35ae195a00ccL38-R81)
* **Image_size, Rational**: Extended definitions to include `None`, enabling more robust handling of video size and frame rate specifications.
* **Sample_fmt, Binary, Func, Time**: Modified type definitions to accept `None`, ensuring compatibility with optional or undefined values.