### PR TITLE
add a --pdb debugger

### DIFF
--- a/src/scripts/main.py
+++ b/src/scripts/main.py
@@ -7,6 +7,10 @@ and parsing utilities. It combines multiple sub-applications into a single CLI t
 different subcommands for each functionality area.
 """
 
+import pdb
+import sys
+from types import TracebackType
+
 import typer
 
 from .code_gen.cli import app as code_gen_app
@@ -15,7 +19,34 @@ from .parse_c.cli import app as parse_c_app
 from .parse_docs.cli import app as parse_docs_app
 from .parse_help.cli import app as parse_help_app
 
+
+def pdb_callback(value: bool) -> None:
+    """Callback for the --pdb option to enable debugger on exceptions."""
+    if value:
+
+        def debugger_hook(
+            exctype: type[BaseException],
+            value: BaseException,
+            traceback: TracebackType | None,
+        ) -> None:
+            if exctype is KeyboardInterrupt:
+                sys.__excepthook__(exctype, value, traceback)
+            else:
+                pdb.post_mortem(traceback)
+
+        sys.excepthook = debugger_hook
+
+
 app = typer.Typer(help="Typed-FFmpeg code generation and parsing utilities")
+
+
+# Add global --pdb option
+@app.callback()
+def main(
+    pdb: bool = typer.Option(False, "--pdb", help="Drop into debugger on exceptions"),
+) -> None:
+    """Typed-FFmpeg code generation and parsing utilities."""
+    pdb_callback(pdb)
 
 
 app.add_typer(parse_help_app, name="parse-help")


### PR DESCRIPTION

- add a `--pdb` options

This pull request introduces a new debugging feature to the `src/scripts/main.py` file, allowing developers to drop into a debugger (`pdb`) on exceptions using a global `--pdb` option. The most important changes include adding the necessary imports, defining a callback function for the `--pdb` option, and modifying the main application to include this option.

### Debugging Feature Enhancements:

* [`src/scripts/main.py`](diffhunk://#diff-81dd1ce32b60dbdb1133c95a56d3185b99839f713c642805204ff6a6a85e8ec6R10-R13): Added imports for `pdb`, `sys`, and `TracebackType` to support debugging functionality.
* [`src/scripts/main.py`](diffhunk://#diff-81dd1ce32b60dbdb1133c95a56d3185b99839f713c642805204ff6a6a85e8ec6R22-R51): Defined the `pdb_callback` function, which sets a custom exception hook to invoke the debugger (`pdb`) on uncaught exceptions.
* [`src/scripts/main.py`](diffhunk://#diff-81dd1ce32b60dbdb1133c95a56d3185b99839f713c642805204ff6a6a85e8ec6R22-R51): Modified the main application to include a global `--pdb` option, which triggers the `pdb_callback` function when enabled.

