### PR TITLE
add dev-only marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,9 @@ ignore = [
 [tool.ruff.format]
 quote-style = "double"
 docstring-code-format = true
+
+[tool.pytest.ini_options]
+markers = [
+    "dev_only: marks tests to be run only on the main branch"
+]
+addopts = "--cov-report=term-missing"

--- a/src/scripts/conftest.py
+++ b/src/scripts/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-dev",
+        action="store_true",
+        default=False,
+        help="Run tests marked as dev_only",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if "dev_only" in item.keywords and not item.config.getoption("--run-dev"):
+        pytest.skip("Skipping dev_only test. Use --run-dev to run it.")


### PR DESCRIPTION
This pull request introduces a new `dev_only` marker for pytest to allow selective execution of tests intended for the main branch. It also adds configuration options to support this marker and ensures tests marked as `dev_only` are skipped unless explicitly enabled.

### Enhancements to pytest configuration:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R126-R131): Added a new `[tool.pytest.ini_options]` section to define the `dev_only` marker and include the `--cov-report=term-missing` option for coverage reporting.

### Implementation of `dev_only` marker functionality:

* [`src/scripts/conftest.py`](diffhunk://#diff-3aef653709f3805afc848066f6598b6ea1af80a9d85814ded19330819b6c07e4R1-R15): Added `pytest_addoption` to define the `--run-dev` command-line option, and implemented `pytest_runtest_setup` to skip tests marked as `dev_only` unless `--run-dev` is specified.