### PR TITLE
generalize render

### DIFF
--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -2,6 +2,7 @@ import keyword
 import pathlib
 from math import isnan
 from pathlib import Path
+from typing import Any
 
 import jinja2
 
@@ -12,8 +13,6 @@ from ffmpeg.common.schema import (
     FFMpegOption,
     FFMpegOptionType,
 )
-
-from ..parse_help.schema import FFMpegCodec, FFMpegFormat
 
 template_folder = Path(__file__).parent / "templates"
 
@@ -251,19 +250,13 @@ env.filters["filter_option_typings"] = filter_option_typings
 
 def render(
     *,
-    filters: list[FFMpegFilter],
-    options: list[FFMpegOption],
-    codecs: list[FFMpegCodec],
-    muxers: list[FFMpegFormat],
     outpath: pathlib.Path,
+    **kwargs: Any,
 ) -> list[pathlib.Path]:
     """
     Render the filter and option documents
 
     Args:
-        filters: The filters
-        options: The options
-        codecs: The codecs
         outpath: The output path
 
     Returns:
@@ -272,13 +265,11 @@ def render(
     outpath.mkdir(exist_ok=True)
     output = []
 
-    for template_file in template_folder.glob("**/*.py.jinja"):
+    for template_file in template_folder.glob("**/*.jinja"):
         template_path = template_file.relative_to(template_folder)
 
         template = env.get_template(str(template_path))
-        code = template.render(
-            filters=filters, options=options, codecs=codecs, muxers=muxers
-        )
+        code = template.render(**kwargs)
 
         opath = outpath / str(template_path).replace(".jinja", "")
         opath.parent.mkdir(parents=True, exist_ok=True)

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -265,7 +265,7 @@ def render(
     outpath.mkdir(exist_ok=True)
     output = []
 
-    for template_file in template_folder.glob("**/*.jinja"):
+    for template_file in template_folder.glob("**/*.*.jinja"):
         template_path = template_file.relative_to(template_folder)
 
         template = env.get_template(str(template_path))


### PR DESCRIPTION
This pull request refactors the `render` function in `src/scripts/code_gen/gen.py` to improve flexibility and streamline the code generation process. The changes include replacing specific arguments with a more generic `**kwargs`, updating template file extensions, and removing unused imports.

Refactoring for flexibility:

* [`src/scripts/code_gen/gen.py`](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621L254-L266): Replaced specific arguments (`filters`, `options`, `codecs`, `muxers`) in the `render` function with a generic `**kwargs` parameter to allow dynamic input handling.
* [`src/scripts/code_gen/gen.py`](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621L275-R272): Modified the `render` function to pass `**kwargs` to the Jinja2 template rendering process, simplifying the code and improving flexibility.

Code cleanup:

* [`src/scripts/code_gen/gen.py`](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621L16-L17): Removed unused imports (`FFMpegCodec`, `FFMpegFormat`) from the `parse_help.schema` module to reduce clutter.
* [`src/scripts/code_gen/gen.py`](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621R5): Added `Any` from the `typing` module to support the `**kwargs` parameter in the `render` function.

Template extension update:

* [`src/scripts/code_gen/gen.py`](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621L275-R272): Updated the glob pattern in the `render` function to look for `.jinja` files instead of `.py.jinja`, reflecting a change in template file naming conventions.