### PR TITLE
Refactor option group

### DIFF
--- a/src/ffmpeg/codecs/decoders.py
+++ b/src/ffmpeg/codecs/decoders.py
@@ -13,7 +13,7 @@ def _012v() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def _4xm() -> FFMpegDecoderOption:
@@ -24,7 +24,7 @@ def _4xm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def _8bps() -> FFMpegDecoderOption:
@@ -35,7 +35,7 @@ def _8bps() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def aasc() -> FFMpegDecoderOption:
@@ -46,7 +46,7 @@ def aasc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def agm() -> FFMpegDecoderOption:
@@ -57,7 +57,7 @@ def agm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def aic() -> FFMpegDecoderOption:
@@ -68,7 +68,7 @@ def aic() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def alias_pix() -> FFMpegDecoderOption:
@@ -79,7 +79,7 @@ def alias_pix() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def amv() -> FFMpegDecoderOption:
@@ -90,7 +90,7 @@ def amv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def anm() -> FFMpegDecoderOption:
@@ -101,7 +101,7 @@ def anm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ansi() -> FFMpegDecoderOption:
@@ -112,7 +112,7 @@ def ansi() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def apng() -> FFMpegDecoderOption:
@@ -123,7 +123,7 @@ def apng() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def arbc() -> FFMpegDecoderOption:
@@ -134,7 +134,7 @@ def arbc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def argo() -> FFMpegDecoderOption:
@@ -145,7 +145,7 @@ def argo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def asv1() -> FFMpegDecoderOption:
@@ -156,7 +156,7 @@ def asv1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def asv2() -> FFMpegDecoderOption:
@@ -167,7 +167,7 @@ def asv2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def aura() -> FFMpegDecoderOption:
@@ -178,7 +178,7 @@ def aura() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def aura2() -> FFMpegDecoderOption:
@@ -189,7 +189,7 @@ def aura2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libdav1d(
@@ -215,7 +215,7 @@ def libdav1d(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "tilethreads": tilethreads,
                 "framethreads": framethreads,
@@ -241,7 +241,7 @@ def av1(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "operating_point": operating_point,
             }
@@ -272,7 +272,7 @@ def av1_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -293,7 +293,7 @@ def avrn() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def avrp() -> FFMpegDecoderOption:
@@ -304,7 +304,7 @@ def avrp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def avs() -> FFMpegDecoderOption:
@@ -315,7 +315,7 @@ def avs() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def avui() -> FFMpegDecoderOption:
@@ -326,7 +326,7 @@ def avui() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ayuv() -> FFMpegDecoderOption:
@@ -337,7 +337,7 @@ def ayuv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bethsoftvid() -> FFMpegDecoderOption:
@@ -348,7 +348,7 @@ def bethsoftvid() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bfi() -> FFMpegDecoderOption:
@@ -359,7 +359,7 @@ def bfi() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def binkvideo() -> FFMpegDecoderOption:
@@ -370,7 +370,7 @@ def binkvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bintext() -> FFMpegDecoderOption:
@@ -381,7 +381,7 @@ def bintext() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bitpacked() -> FFMpegDecoderOption:
@@ -392,7 +392,7 @@ def bitpacked() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bmp() -> FFMpegDecoderOption:
@@ -403,7 +403,7 @@ def bmp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bmv_video() -> FFMpegDecoderOption:
@@ -414,7 +414,7 @@ def bmv_video() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def brender_pix() -> FFMpegDecoderOption:
@@ -425,7 +425,7 @@ def brender_pix() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def c93() -> FFMpegDecoderOption:
@@ -436,7 +436,7 @@ def c93() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cavs() -> FFMpegDecoderOption:
@@ -447,7 +447,7 @@ def cavs() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cdgraphics() -> FFMpegDecoderOption:
@@ -458,7 +458,7 @@ def cdgraphics() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cdtoons() -> FFMpegDecoderOption:
@@ -469,7 +469,7 @@ def cdtoons() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cdxl() -> FFMpegDecoderOption:
@@ -480,7 +480,7 @@ def cdxl() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cfhd() -> FFMpegDecoderOption:
@@ -491,7 +491,7 @@ def cfhd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cinepak() -> FFMpegDecoderOption:
@@ -502,7 +502,7 @@ def cinepak() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def clearvideo() -> FFMpegDecoderOption:
@@ -513,7 +513,7 @@ def clearvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cljr() -> FFMpegDecoderOption:
@@ -524,7 +524,7 @@ def cljr() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cllc() -> FFMpegDecoderOption:
@@ -535,7 +535,7 @@ def cllc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def eacmv() -> FFMpegDecoderOption:
@@ -546,7 +546,7 @@ def eacmv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cpia() -> FFMpegDecoderOption:
@@ -557,7 +557,7 @@ def cpia() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cri() -> FFMpegDecoderOption:
@@ -568,7 +568,7 @@ def cri() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def camstudio() -> FFMpegDecoderOption:
@@ -579,7 +579,7 @@ def camstudio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cyuv() -> FFMpegDecoderOption:
@@ -590,7 +590,7 @@ def cyuv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dds() -> FFMpegDecoderOption:
@@ -601,7 +601,7 @@ def dds() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dfa() -> FFMpegDecoderOption:
@@ -612,7 +612,7 @@ def dfa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dirac() -> FFMpegDecoderOption:
@@ -623,7 +623,7 @@ def dirac() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dnxhd() -> FFMpegDecoderOption:
@@ -634,7 +634,7 @@ def dnxhd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dpx() -> FFMpegDecoderOption:
@@ -645,7 +645,7 @@ def dpx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dsicinvideo() -> FFMpegDecoderOption:
@@ -656,7 +656,7 @@ def dsicinvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dvvideo() -> FFMpegDecoderOption:
@@ -667,7 +667,7 @@ def dvvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dxa() -> FFMpegDecoderOption:
@@ -678,7 +678,7 @@ def dxa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dxtory() -> FFMpegDecoderOption:
@@ -689,7 +689,7 @@ def dxtory() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dxv() -> FFMpegDecoderOption:
@@ -700,7 +700,7 @@ def dxv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def escape124() -> FFMpegDecoderOption:
@@ -711,7 +711,7 @@ def escape124() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def escape130() -> FFMpegDecoderOption:
@@ -722,7 +722,7 @@ def escape130() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def exr(
@@ -763,7 +763,7 @@ def exr(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "layer": layer,
                 "part": part,
@@ -782,7 +782,7 @@ def ffv1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ffvhuff() -> FFMpegDecoderOption:
@@ -793,7 +793,7 @@ def ffvhuff() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def fic(
@@ -809,7 +809,7 @@ def fic(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "skip_cursor": skip_cursor,
             }
@@ -830,7 +830,7 @@ def fits(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "blank_value": blank_value,
             }
@@ -846,7 +846,7 @@ def flashsv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def flashsv2() -> FFMpegDecoderOption:
@@ -857,7 +857,7 @@ def flashsv2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def flic() -> FFMpegDecoderOption:
@@ -868,7 +868,7 @@ def flic() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def flv() -> FFMpegDecoderOption:
@@ -879,7 +879,7 @@ def flv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def fmvc() -> FFMpegDecoderOption:
@@ -890,7 +890,7 @@ def fmvc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def fraps() -> FFMpegDecoderOption:
@@ -901,7 +901,7 @@ def fraps() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def frwu(
@@ -917,7 +917,7 @@ def frwu(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "change_field_order": change_field_order,
             }
@@ -933,7 +933,7 @@ def g2m() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def gdv() -> FFMpegDecoderOption:
@@ -944,7 +944,7 @@ def gdv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def gem() -> FFMpegDecoderOption:
@@ -955,7 +955,7 @@ def gem() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def gif(
@@ -971,7 +971,7 @@ def gif(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "trans_color": trans_color,
             }
@@ -987,7 +987,7 @@ def h261() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def h263() -> FFMpegDecoderOption:
@@ -998,7 +998,7 @@ def h263() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def h263_v4l2m2m(
@@ -1016,7 +1016,7 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1033,7 +1033,7 @@ def h263i() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def h263p() -> FFMpegDecoderOption:
@@ -1044,7 +1044,7 @@ def h263p() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def h264(
@@ -1066,7 +1066,7 @@ def h264(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "is_avc": is_avc,
                 "nal_length_size": nal_length_size,
@@ -1092,7 +1092,7 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1124,7 +1124,7 @@ def h264_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -1145,7 +1145,7 @@ def hap() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hdr() -> FFMpegDecoderOption:
@@ -1156,7 +1156,7 @@ def hdr() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hevc(
@@ -1174,7 +1174,7 @@ def hevc(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "apply_defdispwin": apply_defdispwin,
                 "strict-displaywin": strict_displaywin,
@@ -1198,7 +1198,7 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1230,7 +1230,7 @@ def hevc_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -1251,7 +1251,7 @@ def hnm4video() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hq_hqa() -> FFMpegDecoderOption:
@@ -1262,7 +1262,7 @@ def hq_hqa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hqx() -> FFMpegDecoderOption:
@@ -1273,7 +1273,7 @@ def hqx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def huffyuv() -> FFMpegDecoderOption:
@@ -1284,7 +1284,7 @@ def huffyuv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hymt() -> FFMpegDecoderOption:
@@ -1295,7 +1295,7 @@ def hymt() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def idcinvideo() -> FFMpegDecoderOption:
@@ -1306,7 +1306,7 @@ def idcinvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def idf() -> FFMpegDecoderOption:
@@ -1317,7 +1317,7 @@ def idf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def iff() -> FFMpegDecoderOption:
@@ -1328,7 +1328,7 @@ def iff() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def imm4() -> FFMpegDecoderOption:
@@ -1339,7 +1339,7 @@ def imm4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def imm5() -> FFMpegDecoderOption:
@@ -1350,7 +1350,7 @@ def imm5() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def indeo2() -> FFMpegDecoderOption:
@@ -1361,7 +1361,7 @@ def indeo2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def indeo3() -> FFMpegDecoderOption:
@@ -1372,7 +1372,7 @@ def indeo3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def indeo4() -> FFMpegDecoderOption:
@@ -1383,7 +1383,7 @@ def indeo4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def indeo5() -> FFMpegDecoderOption:
@@ -1394,7 +1394,7 @@ def indeo5() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def interplayvideo() -> FFMpegDecoderOption:
@@ -1405,7 +1405,7 @@ def interplayvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ipu() -> FFMpegDecoderOption:
@@ -1416,7 +1416,7 @@ def ipu() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def jpeg2000(
@@ -1432,7 +1432,7 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lowres": lowres,
             }
@@ -1448,7 +1448,7 @@ def jpegls() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libjxl() -> FFMpegDecoderOption:
@@ -1459,7 +1459,7 @@ def libjxl() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def jv() -> FFMpegDecoderOption:
@@ -1470,7 +1470,7 @@ def jv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def kgv1() -> FFMpegDecoderOption:
@@ -1481,7 +1481,7 @@ def kgv1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def kmvc() -> FFMpegDecoderOption:
@@ -1492,7 +1492,7 @@ def kmvc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def lagarith() -> FFMpegDecoderOption:
@@ -1503,7 +1503,7 @@ def lagarith() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def loco() -> FFMpegDecoderOption:
@@ -1514,7 +1514,7 @@ def loco() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def lscr() -> FFMpegDecoderOption:
@@ -1525,7 +1525,7 @@ def lscr() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def m101() -> FFMpegDecoderOption:
@@ -1536,7 +1536,7 @@ def m101() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def eamad() -> FFMpegDecoderOption:
@@ -1547,7 +1547,7 @@ def eamad() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def magicyuv() -> FFMpegDecoderOption:
@@ -1558,7 +1558,7 @@ def magicyuv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mdec() -> FFMpegDecoderOption:
@@ -1569,7 +1569,7 @@ def mdec() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def media100() -> FFMpegDecoderOption:
@@ -1580,7 +1580,7 @@ def media100() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mimic() -> FFMpegDecoderOption:
@@ -1591,7 +1591,7 @@ def mimic() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mjpeg(
@@ -1607,7 +1607,7 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "extern_huff": extern_huff,
             }
@@ -1638,7 +1638,7 @@ def mjpeg_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -1659,7 +1659,7 @@ def mjpegb() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mmvideo() -> FFMpegDecoderOption:
@@ -1670,7 +1670,7 @@ def mmvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mobiclip() -> FFMpegDecoderOption:
@@ -1681,7 +1681,7 @@ def mobiclip() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def motionpixels() -> FFMpegDecoderOption:
@@ -1692,7 +1692,7 @@ def motionpixels() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpeg1video() -> FFMpegDecoderOption:
@@ -1703,7 +1703,7 @@ def mpeg1video() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpeg1_v4l2m2m(
@@ -1721,7 +1721,7 @@ def mpeg1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1753,7 +1753,7 @@ def mpeg1_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -1774,7 +1774,7 @@ def mpeg2video() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpegvideo() -> FFMpegDecoderOption:
@@ -1785,7 +1785,7 @@ def mpegvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpeg2_v4l2m2m(
@@ -1803,7 +1803,7 @@ def mpeg2_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1835,7 +1835,7 @@ def mpeg2_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -1856,7 +1856,7 @@ def mpeg4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpeg4_v4l2m2m(
@@ -1874,7 +1874,7 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1906,7 +1906,7 @@ def mpeg4_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -1927,7 +1927,7 @@ def msa1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mscc() -> FFMpegDecoderOption:
@@ -1938,7 +1938,7 @@ def mscc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msmpeg4v1() -> FFMpegDecoderOption:
@@ -1949,7 +1949,7 @@ def msmpeg4v1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msmpeg4v2() -> FFMpegDecoderOption:
@@ -1960,7 +1960,7 @@ def msmpeg4v2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msmpeg4() -> FFMpegDecoderOption:
@@ -1971,7 +1971,7 @@ def msmpeg4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msp2() -> FFMpegDecoderOption:
@@ -1982,7 +1982,7 @@ def msp2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msrle() -> FFMpegDecoderOption:
@@ -1993,7 +1993,7 @@ def msrle() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mss1() -> FFMpegDecoderOption:
@@ -2004,7 +2004,7 @@ def mss1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mss2() -> FFMpegDecoderOption:
@@ -2015,7 +2015,7 @@ def mss2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msvideo1() -> FFMpegDecoderOption:
@@ -2026,7 +2026,7 @@ def msvideo1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mszh() -> FFMpegDecoderOption:
@@ -2037,7 +2037,7 @@ def mszh() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mts2() -> FFMpegDecoderOption:
@@ -2048,7 +2048,7 @@ def mts2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mv30() -> FFMpegDecoderOption:
@@ -2059,7 +2059,7 @@ def mv30() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mvc1() -> FFMpegDecoderOption:
@@ -2070,7 +2070,7 @@ def mvc1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mvc2() -> FFMpegDecoderOption:
@@ -2081,7 +2081,7 @@ def mvc2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mvdv() -> FFMpegDecoderOption:
@@ -2092,7 +2092,7 @@ def mvdv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mvha() -> FFMpegDecoderOption:
@@ -2103,7 +2103,7 @@ def mvha() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mwsc() -> FFMpegDecoderOption:
@@ -2114,7 +2114,7 @@ def mwsc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mxpeg() -> FFMpegDecoderOption:
@@ -2125,7 +2125,7 @@ def mxpeg() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def notchlc() -> FFMpegDecoderOption:
@@ -2136,7 +2136,7 @@ def notchlc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def nuv() -> FFMpegDecoderOption:
@@ -2147,7 +2147,7 @@ def nuv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def paf_video() -> FFMpegDecoderOption:
@@ -2158,7 +2158,7 @@ def paf_video() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pam() -> FFMpegDecoderOption:
@@ -2169,7 +2169,7 @@ def pam() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pbm() -> FFMpegDecoderOption:
@@ -2180,7 +2180,7 @@ def pbm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcx() -> FFMpegDecoderOption:
@@ -2191,7 +2191,7 @@ def pcx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pdv() -> FFMpegDecoderOption:
@@ -2202,7 +2202,7 @@ def pdv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pfm() -> FFMpegDecoderOption:
@@ -2213,7 +2213,7 @@ def pfm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pgm() -> FFMpegDecoderOption:
@@ -2224,7 +2224,7 @@ def pgm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pgmyuv() -> FFMpegDecoderOption:
@@ -2235,7 +2235,7 @@ def pgmyuv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pgx() -> FFMpegDecoderOption:
@@ -2246,7 +2246,7 @@ def pgx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def phm() -> FFMpegDecoderOption:
@@ -2257,7 +2257,7 @@ def phm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def photocd(
@@ -2273,7 +2273,7 @@ def photocd(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lowres": lowres,
             }
@@ -2289,7 +2289,7 @@ def pictor() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pixlet() -> FFMpegDecoderOption:
@@ -2300,7 +2300,7 @@ def pixlet() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def png() -> FFMpegDecoderOption:
@@ -2311,7 +2311,7 @@ def png() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ppm() -> FFMpegDecoderOption:
@@ -2322,7 +2322,7 @@ def ppm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def prores() -> FFMpegDecoderOption:
@@ -2333,7 +2333,7 @@ def prores() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def prosumer() -> FFMpegDecoderOption:
@@ -2344,7 +2344,7 @@ def prosumer() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def psd() -> FFMpegDecoderOption:
@@ -2355,7 +2355,7 @@ def psd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ptx() -> FFMpegDecoderOption:
@@ -2366,7 +2366,7 @@ def ptx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qdraw() -> FFMpegDecoderOption:
@@ -2377,7 +2377,7 @@ def qdraw() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qoi() -> FFMpegDecoderOption:
@@ -2388,7 +2388,7 @@ def qoi() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qpeg() -> FFMpegDecoderOption:
@@ -2399,7 +2399,7 @@ def qpeg() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qtrle() -> FFMpegDecoderOption:
@@ -2410,7 +2410,7 @@ def qtrle() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def r10k() -> FFMpegDecoderOption:
@@ -2421,7 +2421,7 @@ def r10k() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def r210() -> FFMpegDecoderOption:
@@ -2432,7 +2432,7 @@ def r210() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rasc(
@@ -2448,7 +2448,7 @@ def rasc(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "skip_cursor": skip_cursor,
             }
@@ -2469,7 +2469,7 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "top": top,
             }
@@ -2485,7 +2485,7 @@ def rl2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def roqvideo() -> FFMpegDecoderOption:
@@ -2496,7 +2496,7 @@ def roqvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rpza() -> FFMpegDecoderOption:
@@ -2507,7 +2507,7 @@ def rpza() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rscc() -> FFMpegDecoderOption:
@@ -2518,7 +2518,7 @@ def rscc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rtv1() -> FFMpegDecoderOption:
@@ -2529,7 +2529,7 @@ def rtv1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rv10() -> FFMpegDecoderOption:
@@ -2540,7 +2540,7 @@ def rv10() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rv20() -> FFMpegDecoderOption:
@@ -2551,7 +2551,7 @@ def rv20() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rv30() -> FFMpegDecoderOption:
@@ -2562,7 +2562,7 @@ def rv30() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rv40() -> FFMpegDecoderOption:
@@ -2573,7 +2573,7 @@ def rv40() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sanm() -> FFMpegDecoderOption:
@@ -2584,7 +2584,7 @@ def sanm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def scpr() -> FFMpegDecoderOption:
@@ -2595,7 +2595,7 @@ def scpr() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def screenpresso() -> FFMpegDecoderOption:
@@ -2606,7 +2606,7 @@ def screenpresso() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sga() -> FFMpegDecoderOption:
@@ -2617,7 +2617,7 @@ def sga() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sgi() -> FFMpegDecoderOption:
@@ -2628,7 +2628,7 @@ def sgi() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sgirle() -> FFMpegDecoderOption:
@@ -2639,7 +2639,7 @@ def sgirle() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sheervideo() -> FFMpegDecoderOption:
@@ -2650,7 +2650,7 @@ def sheervideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def simbiosis_imx() -> FFMpegDecoderOption:
@@ -2661,7 +2661,7 @@ def simbiosis_imx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def smackvid() -> FFMpegDecoderOption:
@@ -2672,7 +2672,7 @@ def smackvid() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def smc() -> FFMpegDecoderOption:
@@ -2683,7 +2683,7 @@ def smc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def smvjpeg() -> FFMpegDecoderOption:
@@ -2694,7 +2694,7 @@ def smvjpeg() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def snow() -> FFMpegDecoderOption:
@@ -2705,7 +2705,7 @@ def snow() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sp5x() -> FFMpegDecoderOption:
@@ -2716,7 +2716,7 @@ def sp5x() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def speedhq() -> FFMpegDecoderOption:
@@ -2727,7 +2727,7 @@ def speedhq() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def srgc() -> FFMpegDecoderOption:
@@ -2738,7 +2738,7 @@ def srgc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sunrast() -> FFMpegDecoderOption:
@@ -2749,7 +2749,7 @@ def sunrast() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def librsvg(
@@ -2769,7 +2769,7 @@ def librsvg(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "width": width,
                 "height": height,
@@ -2787,7 +2787,7 @@ def svq1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def svq3() -> FFMpegDecoderOption:
@@ -2798,7 +2798,7 @@ def svq3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def targa() -> FFMpegDecoderOption:
@@ -2809,7 +2809,7 @@ def targa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def targa_y216() -> FFMpegDecoderOption:
@@ -2820,7 +2820,7 @@ def targa_y216() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def tdsc() -> FFMpegDecoderOption:
@@ -2831,7 +2831,7 @@ def tdsc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def eatgq() -> FFMpegDecoderOption:
@@ -2842,7 +2842,7 @@ def eatgq() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def eatgv() -> FFMpegDecoderOption:
@@ -2853,7 +2853,7 @@ def eatgv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def theora() -> FFMpegDecoderOption:
@@ -2864,7 +2864,7 @@ def theora() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def thp() -> FFMpegDecoderOption:
@@ -2875,7 +2875,7 @@ def thp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def tiertexseqvideo() -> FFMpegDecoderOption:
@@ -2886,7 +2886,7 @@ def tiertexseqvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def tiff(
@@ -2906,7 +2906,7 @@ def tiff(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "subimage": subimage,
                 "thumbnail": thumbnail,
@@ -2924,7 +2924,7 @@ def tmv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def eatqi() -> FFMpegDecoderOption:
@@ -2935,7 +2935,7 @@ def eatqi() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def truemotion1() -> FFMpegDecoderOption:
@@ -2946,7 +2946,7 @@ def truemotion1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def truemotion2() -> FFMpegDecoderOption:
@@ -2957,7 +2957,7 @@ def truemotion2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def truemotion2rt() -> FFMpegDecoderOption:
@@ -2968,7 +2968,7 @@ def truemotion2rt() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def camtasia() -> FFMpegDecoderOption:
@@ -2979,7 +2979,7 @@ def camtasia() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def tscc2() -> FFMpegDecoderOption:
@@ -2990,7 +2990,7 @@ def tscc2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def txd() -> FFMpegDecoderOption:
@@ -3001,7 +3001,7 @@ def txd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ultimotion() -> FFMpegDecoderOption:
@@ -3012,7 +3012,7 @@ def ultimotion() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def utvideo() -> FFMpegDecoderOption:
@@ -3023,7 +3023,7 @@ def utvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def v210(
@@ -3039,7 +3039,7 @@ def v210(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "custom_stride": custom_stride,
             }
@@ -3055,7 +3055,7 @@ def v210x() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def v308() -> FFMpegDecoderOption:
@@ -3066,7 +3066,7 @@ def v308() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def v408() -> FFMpegDecoderOption:
@@ -3077,7 +3077,7 @@ def v408() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def v410() -> FFMpegDecoderOption:
@@ -3088,7 +3088,7 @@ def v410() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vb() -> FFMpegDecoderOption:
@@ -3099,7 +3099,7 @@ def vb() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vble() -> FFMpegDecoderOption:
@@ -3110,7 +3110,7 @@ def vble() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vbn() -> FFMpegDecoderOption:
@@ -3121,7 +3121,7 @@ def vbn() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vc1() -> FFMpegDecoderOption:
@@ -3132,7 +3132,7 @@ def vc1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vc1_v4l2m2m(
@@ -3150,7 +3150,7 @@ def vc1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -3182,7 +3182,7 @@ def vc1_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -3203,7 +3203,7 @@ def vc1image() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vcr1() -> FFMpegDecoderOption:
@@ -3214,7 +3214,7 @@ def vcr1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xl() -> FFMpegDecoderOption:
@@ -3225,7 +3225,7 @@ def xl() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vmdvideo() -> FFMpegDecoderOption:
@@ -3236,7 +3236,7 @@ def vmdvideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vmix() -> FFMpegDecoderOption:
@@ -3247,7 +3247,7 @@ def vmix() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vmnc() -> FFMpegDecoderOption:
@@ -3258,7 +3258,7 @@ def vmnc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vnull() -> FFMpegDecoderOption:
@@ -3269,7 +3269,7 @@ def vnull() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp3() -> FFMpegDecoderOption:
@@ -3280,7 +3280,7 @@ def vp3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp4() -> FFMpegDecoderOption:
@@ -3291,7 +3291,7 @@ def vp4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp5() -> FFMpegDecoderOption:
@@ -3302,7 +3302,7 @@ def vp5() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp6() -> FFMpegDecoderOption:
@@ -3313,7 +3313,7 @@ def vp6() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp6a() -> FFMpegDecoderOption:
@@ -3324,7 +3324,7 @@ def vp6a() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp6f() -> FFMpegDecoderOption:
@@ -3335,7 +3335,7 @@ def vp6f() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp7() -> FFMpegDecoderOption:
@@ -3346,7 +3346,7 @@ def vp7() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp8() -> FFMpegDecoderOption:
@@ -3357,7 +3357,7 @@ def vp8() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp8_v4l2m2m(
@@ -3375,7 +3375,7 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -3392,7 +3392,7 @@ def libvpx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp8_cuvid(
@@ -3418,7 +3418,7 @@ def vp8_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -3439,7 +3439,7 @@ def vp9() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vp9_v4l2m2m(
@@ -3457,7 +3457,7 @@ def vp9_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -3489,7 +3489,7 @@ def vp9_cuvid(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "deint": deint,
                 "gpu": gpu,
@@ -3510,7 +3510,7 @@ def vqc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wbmp() -> FFMpegDecoderOption:
@@ -3521,7 +3521,7 @@ def wbmp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wcmv() -> FFMpegDecoderOption:
@@ -3532,7 +3532,7 @@ def wcmv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def webp() -> FFMpegDecoderOption:
@@ -3543,7 +3543,7 @@ def webp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmv1() -> FFMpegDecoderOption:
@@ -3554,7 +3554,7 @@ def wmv1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmv2() -> FFMpegDecoderOption:
@@ -3565,7 +3565,7 @@ def wmv2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmv3() -> FFMpegDecoderOption:
@@ -3576,7 +3576,7 @@ def wmv3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmv3image() -> FFMpegDecoderOption:
@@ -3587,7 +3587,7 @@ def wmv3image() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wnv1() -> FFMpegDecoderOption:
@@ -3598,7 +3598,7 @@ def wnv1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wrapped_avframe() -> FFMpegDecoderOption:
@@ -3609,7 +3609,7 @@ def wrapped_avframe() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vqavideo() -> FFMpegDecoderOption:
@@ -3620,7 +3620,7 @@ def vqavideo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xan_wc3() -> FFMpegDecoderOption:
@@ -3631,7 +3631,7 @@ def xan_wc3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xan_wc4() -> FFMpegDecoderOption:
@@ -3642,7 +3642,7 @@ def xan_wc4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xbin() -> FFMpegDecoderOption:
@@ -3653,7 +3653,7 @@ def xbin() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xbm() -> FFMpegDecoderOption:
@@ -3664,7 +3664,7 @@ def xbm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xface() -> FFMpegDecoderOption:
@@ -3675,7 +3675,7 @@ def xface() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xpm() -> FFMpegDecoderOption:
@@ -3686,7 +3686,7 @@ def xpm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xwd() -> FFMpegDecoderOption:
@@ -3697,7 +3697,7 @@ def xwd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def y41p() -> FFMpegDecoderOption:
@@ -3708,7 +3708,7 @@ def y41p() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ylc() -> FFMpegDecoderOption:
@@ -3719,7 +3719,7 @@ def ylc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def yop() -> FFMpegDecoderOption:
@@ -3730,7 +3730,7 @@ def yop() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def yuv4() -> FFMpegDecoderOption:
@@ -3741,7 +3741,7 @@ def yuv4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def zerocodec() -> FFMpegDecoderOption:
@@ -3752,7 +3752,7 @@ def zerocodec() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def zlib() -> FFMpegDecoderOption:
@@ -3763,7 +3763,7 @@ def zlib() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def zmbv() -> FFMpegDecoderOption:
@@ -3774,7 +3774,7 @@ def zmbv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def _8svx_exp() -> FFMpegDecoderOption:
@@ -3785,7 +3785,7 @@ def _8svx_exp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def _8svx_fib() -> FFMpegDecoderOption:
@@ -3796,7 +3796,7 @@ def _8svx_fib() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def aac(
@@ -3814,7 +3814,7 @@ def aac(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dual_mono_mode": dual_mono_mode,
                 "channel_order": channel_order,
@@ -3838,7 +3838,7 @@ def aac_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dual_mono_mode": dual_mono_mode,
                 "channel_order": channel_order,
@@ -3855,7 +3855,7 @@ def aac_latm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ac3(
@@ -3879,7 +3879,7 @@ def ac3(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "cons_noisegen": cons_noisegen,
                 "drc_scale": drc_scale,
@@ -3910,7 +3910,7 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "cons_noisegen": cons_noisegen,
                 "drc_scale": drc_scale,
@@ -3929,7 +3929,7 @@ def adpcm_4xm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_adx() -> FFMpegDecoderOption:
@@ -3940,7 +3940,7 @@ def adpcm_adx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_afc() -> FFMpegDecoderOption:
@@ -3951,7 +3951,7 @@ def adpcm_afc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_agm() -> FFMpegDecoderOption:
@@ -3962,7 +3962,7 @@ def adpcm_agm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_aica() -> FFMpegDecoderOption:
@@ -3973,7 +3973,7 @@ def adpcm_aica() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_argo() -> FFMpegDecoderOption:
@@ -3984,7 +3984,7 @@ def adpcm_argo() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ct() -> FFMpegDecoderOption:
@@ -3995,7 +3995,7 @@ def adpcm_ct() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_dtk() -> FFMpegDecoderOption:
@@ -4006,7 +4006,7 @@ def adpcm_dtk() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ea() -> FFMpegDecoderOption:
@@ -4017,7 +4017,7 @@ def adpcm_ea() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ea_maxis_xa() -> FFMpegDecoderOption:
@@ -4028,7 +4028,7 @@ def adpcm_ea_maxis_xa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ea_r1() -> FFMpegDecoderOption:
@@ -4039,7 +4039,7 @@ def adpcm_ea_r1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ea_r2() -> FFMpegDecoderOption:
@@ -4050,7 +4050,7 @@ def adpcm_ea_r2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ea_r3() -> FFMpegDecoderOption:
@@ -4061,7 +4061,7 @@ def adpcm_ea_r3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ea_xas() -> FFMpegDecoderOption:
@@ -4072,7 +4072,7 @@ def adpcm_ea_xas() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def g722(
@@ -4088,7 +4088,7 @@ def g722(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "bits_per_codeword": bits_per_codeword,
             }
@@ -4104,7 +4104,7 @@ def g726() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def g726le() -> FFMpegDecoderOption:
@@ -4115,7 +4115,7 @@ def g726le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_acorn() -> FFMpegDecoderOption:
@@ -4126,7 +4126,7 @@ def adpcm_ima_acorn() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_alp() -> FFMpegDecoderOption:
@@ -4137,7 +4137,7 @@ def adpcm_ima_alp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_amv() -> FFMpegDecoderOption:
@@ -4148,7 +4148,7 @@ def adpcm_ima_amv() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_apc() -> FFMpegDecoderOption:
@@ -4159,7 +4159,7 @@ def adpcm_ima_apc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_apm() -> FFMpegDecoderOption:
@@ -4170,7 +4170,7 @@ def adpcm_ima_apm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_cunning() -> FFMpegDecoderOption:
@@ -4181,7 +4181,7 @@ def adpcm_ima_cunning() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_dat4() -> FFMpegDecoderOption:
@@ -4192,7 +4192,7 @@ def adpcm_ima_dat4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_dk3() -> FFMpegDecoderOption:
@@ -4203,7 +4203,7 @@ def adpcm_ima_dk3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_dk4() -> FFMpegDecoderOption:
@@ -4214,7 +4214,7 @@ def adpcm_ima_dk4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_ea_eacs() -> FFMpegDecoderOption:
@@ -4225,7 +4225,7 @@ def adpcm_ima_ea_eacs() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_ea_sead() -> FFMpegDecoderOption:
@@ -4236,7 +4236,7 @@ def adpcm_ima_ea_sead() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_iss() -> FFMpegDecoderOption:
@@ -4247,7 +4247,7 @@ def adpcm_ima_iss() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_moflex() -> FFMpegDecoderOption:
@@ -4258,7 +4258,7 @@ def adpcm_ima_moflex() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_mtf() -> FFMpegDecoderOption:
@@ -4269,7 +4269,7 @@ def adpcm_ima_mtf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_oki() -> FFMpegDecoderOption:
@@ -4280,7 +4280,7 @@ def adpcm_ima_oki() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_qt() -> FFMpegDecoderOption:
@@ -4291,7 +4291,7 @@ def adpcm_ima_qt() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_rad() -> FFMpegDecoderOption:
@@ -4302,7 +4302,7 @@ def adpcm_ima_rad() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_smjpeg() -> FFMpegDecoderOption:
@@ -4313,7 +4313,7 @@ def adpcm_ima_smjpeg() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_ssi() -> FFMpegDecoderOption:
@@ -4324,7 +4324,7 @@ def adpcm_ima_ssi() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_wav() -> FFMpegDecoderOption:
@@ -4335,7 +4335,7 @@ def adpcm_ima_wav() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ima_ws() -> FFMpegDecoderOption:
@@ -4346,7 +4346,7 @@ def adpcm_ima_ws() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_ms() -> FFMpegDecoderOption:
@@ -4357,7 +4357,7 @@ def adpcm_ms() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_mtaf() -> FFMpegDecoderOption:
@@ -4368,7 +4368,7 @@ def adpcm_mtaf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_psx() -> FFMpegDecoderOption:
@@ -4379,7 +4379,7 @@ def adpcm_psx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_sbpro_2() -> FFMpegDecoderOption:
@@ -4390,7 +4390,7 @@ def adpcm_sbpro_2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_sbpro_3() -> FFMpegDecoderOption:
@@ -4401,7 +4401,7 @@ def adpcm_sbpro_3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_sbpro_4() -> FFMpegDecoderOption:
@@ -4412,7 +4412,7 @@ def adpcm_sbpro_4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_swf() -> FFMpegDecoderOption:
@@ -4423,7 +4423,7 @@ def adpcm_swf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_thp() -> FFMpegDecoderOption:
@@ -4434,7 +4434,7 @@ def adpcm_thp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_thp_le() -> FFMpegDecoderOption:
@@ -4445,7 +4445,7 @@ def adpcm_thp_le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_vima() -> FFMpegDecoderOption:
@@ -4456,7 +4456,7 @@ def adpcm_vima() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_xa() -> FFMpegDecoderOption:
@@ -4467,7 +4467,7 @@ def adpcm_xa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_xmd() -> FFMpegDecoderOption:
@@ -4478,7 +4478,7 @@ def adpcm_xmd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_yamaha() -> FFMpegDecoderOption:
@@ -4489,7 +4489,7 @@ def adpcm_yamaha() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def adpcm_zork() -> FFMpegDecoderOption:
@@ -4500,7 +4500,7 @@ def adpcm_zork() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def alac(
@@ -4516,7 +4516,7 @@ def alac(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "extra_bits_bug": extra_bits_bug,
             }
@@ -4532,7 +4532,7 @@ def amrnb() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def amrwb() -> FFMpegDecoderOption:
@@ -4543,7 +4543,7 @@ def amrwb() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def anull() -> FFMpegDecoderOption:
@@ -4554,7 +4554,7 @@ def anull() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def apac() -> FFMpegDecoderOption:
@@ -4565,7 +4565,7 @@ def apac() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ape(
@@ -4581,7 +4581,7 @@ def ape(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "max_samples": max_samples,
             }
@@ -4597,7 +4597,7 @@ def aptx() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def aptx_hd() -> FFMpegDecoderOption:
@@ -4608,7 +4608,7 @@ def aptx_hd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def atrac1() -> FFMpegDecoderOption:
@@ -4619,7 +4619,7 @@ def atrac1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def atrac3() -> FFMpegDecoderOption:
@@ -4630,7 +4630,7 @@ def atrac3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def atrac3al() -> FFMpegDecoderOption:
@@ -4641,7 +4641,7 @@ def atrac3al() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def atrac3plus() -> FFMpegDecoderOption:
@@ -4652,7 +4652,7 @@ def atrac3plus() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def atrac3plusal() -> FFMpegDecoderOption:
@@ -4663,7 +4663,7 @@ def atrac3plusal() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def atrac9() -> FFMpegDecoderOption:
@@ -4674,7 +4674,7 @@ def atrac9() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def on2avc() -> FFMpegDecoderOption:
@@ -4685,7 +4685,7 @@ def on2avc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def binkaudio_dct() -> FFMpegDecoderOption:
@@ -4696,7 +4696,7 @@ def binkaudio_dct() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def binkaudio_rdft() -> FFMpegDecoderOption:
@@ -4707,7 +4707,7 @@ def binkaudio_rdft() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bmv_audio() -> FFMpegDecoderOption:
@@ -4718,7 +4718,7 @@ def bmv_audio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def bonk() -> FFMpegDecoderOption:
@@ -4729,7 +4729,7 @@ def bonk() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cbd2_dpcm() -> FFMpegDecoderOption:
@@ -4740,7 +4740,7 @@ def cbd2_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libcodec2() -> FFMpegDecoderOption:
@@ -4751,7 +4751,7 @@ def libcodec2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def comfortnoise() -> FFMpegDecoderOption:
@@ -4762,7 +4762,7 @@ def comfortnoise() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def cook() -> FFMpegDecoderOption:
@@ -4773,7 +4773,7 @@ def cook() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def derf_dpcm() -> FFMpegDecoderOption:
@@ -4784,7 +4784,7 @@ def derf_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dfpwm() -> FFMpegDecoderOption:
@@ -4795,7 +4795,7 @@ def dfpwm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dolby_e(
@@ -4811,7 +4811,7 @@ def dolby_e(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "channel_order": channel_order,
             }
@@ -4827,7 +4827,7 @@ def dsd_lsbf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dsd_lsbf_planar() -> FFMpegDecoderOption:
@@ -4838,7 +4838,7 @@ def dsd_lsbf_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dsd_msbf() -> FFMpegDecoderOption:
@@ -4849,7 +4849,7 @@ def dsd_msbf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dsd_msbf_planar() -> FFMpegDecoderOption:
@@ -4860,7 +4860,7 @@ def dsd_msbf_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dsicinaudio() -> FFMpegDecoderOption:
@@ -4871,7 +4871,7 @@ def dsicinaudio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dss_sp() -> FFMpegDecoderOption:
@@ -4882,7 +4882,7 @@ def dss_sp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dst() -> FFMpegDecoderOption:
@@ -4893,7 +4893,7 @@ def dst() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dca(
@@ -4913,7 +4913,7 @@ def dca(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "core_only": core_only,
                 "channel_order": channel_order,
@@ -4931,7 +4931,7 @@ def dvaudio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def eac3(
@@ -4955,7 +4955,7 @@ def eac3(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "cons_noisegen": cons_noisegen,
                 "drc_scale": drc_scale,
@@ -4980,7 +4980,7 @@ def evrc(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "postfilter": postfilter,
             }
@@ -4996,7 +4996,7 @@ def fastaudio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def flac(
@@ -5012,7 +5012,7 @@ def flac(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "use_buggy_lpc": use_buggy_lpc,
             }
@@ -5028,7 +5028,7 @@ def ftr() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def g723_1(
@@ -5044,7 +5044,7 @@ def g723_1(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "postfilter": postfilter,
             }
@@ -5060,7 +5060,7 @@ def g729() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def gremlin_dpcm() -> FFMpegDecoderOption:
@@ -5071,7 +5071,7 @@ def gremlin_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def gsm() -> FFMpegDecoderOption:
@@ -5082,7 +5082,7 @@ def gsm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libgsm() -> FFMpegDecoderOption:
@@ -5093,7 +5093,7 @@ def libgsm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def gsm_ms() -> FFMpegDecoderOption:
@@ -5104,7 +5104,7 @@ def gsm_ms() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libgsm_ms() -> FFMpegDecoderOption:
@@ -5115,7 +5115,7 @@ def libgsm_ms() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hca() -> FFMpegDecoderOption:
@@ -5126,7 +5126,7 @@ def hca() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def hcom() -> FFMpegDecoderOption:
@@ -5137,7 +5137,7 @@ def hcom() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def iac() -> FFMpegDecoderOption:
@@ -5148,7 +5148,7 @@ def iac() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ilbc() -> FFMpegDecoderOption:
@@ -5159,7 +5159,7 @@ def ilbc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def imc() -> FFMpegDecoderOption:
@@ -5170,7 +5170,7 @@ def imc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def interplay_dpcm() -> FFMpegDecoderOption:
@@ -5181,7 +5181,7 @@ def interplay_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def interplayacm() -> FFMpegDecoderOption:
@@ -5192,7 +5192,7 @@ def interplayacm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mace3() -> FFMpegDecoderOption:
@@ -5203,7 +5203,7 @@ def mace3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mace6() -> FFMpegDecoderOption:
@@ -5214,7 +5214,7 @@ def mace6() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def metasound() -> FFMpegDecoderOption:
@@ -5225,7 +5225,7 @@ def metasound() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def misc4() -> FFMpegDecoderOption:
@@ -5236,7 +5236,7 @@ def misc4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mlp(
@@ -5252,7 +5252,7 @@ def mlp(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "downmix": downmix,
             }
@@ -5268,7 +5268,7 @@ def mp1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp1float() -> FFMpegDecoderOption:
@@ -5279,7 +5279,7 @@ def mp1float() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp2() -> FFMpegDecoderOption:
@@ -5290,7 +5290,7 @@ def mp2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp2float() -> FFMpegDecoderOption:
@@ -5301,7 +5301,7 @@ def mp2float() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp3float() -> FFMpegDecoderOption:
@@ -5312,7 +5312,7 @@ def mp3float() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp3() -> FFMpegDecoderOption:
@@ -5323,7 +5323,7 @@ def mp3() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp3adufloat() -> FFMpegDecoderOption:
@@ -5334,7 +5334,7 @@ def mp3adufloat() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp3adu() -> FFMpegDecoderOption:
@@ -5345,7 +5345,7 @@ def mp3adu() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp3on4float() -> FFMpegDecoderOption:
@@ -5356,7 +5356,7 @@ def mp3on4float() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mp3on4() -> FFMpegDecoderOption:
@@ -5367,7 +5367,7 @@ def mp3on4() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def als() -> FFMpegDecoderOption:
@@ -5378,7 +5378,7 @@ def als() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def msnsiren() -> FFMpegDecoderOption:
@@ -5389,7 +5389,7 @@ def msnsiren() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpc7() -> FFMpegDecoderOption:
@@ -5400,7 +5400,7 @@ def mpc7() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mpc8() -> FFMpegDecoderOption:
@@ -5411,7 +5411,7 @@ def mpc8() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def nellymoser() -> FFMpegDecoderOption:
@@ -5422,7 +5422,7 @@ def nellymoser() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def opus(
@@ -5438,7 +5438,7 @@ def opus(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "apply_phase_inv": apply_phase_inv,
             }
@@ -5459,7 +5459,7 @@ def libopus(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "apply_phase_inv": apply_phase_inv,
             }
@@ -5475,7 +5475,7 @@ def osq() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def paf_audio() -> FFMpegDecoderOption:
@@ -5486,7 +5486,7 @@ def paf_audio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_alaw() -> FFMpegDecoderOption:
@@ -5497,7 +5497,7 @@ def pcm_alaw() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_bluray() -> FFMpegDecoderOption:
@@ -5508,7 +5508,7 @@ def pcm_bluray() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_dvd() -> FFMpegDecoderOption:
@@ -5519,7 +5519,7 @@ def pcm_dvd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_f16le() -> FFMpegDecoderOption:
@@ -5530,7 +5530,7 @@ def pcm_f16le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_f24le() -> FFMpegDecoderOption:
@@ -5541,7 +5541,7 @@ def pcm_f24le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_f32be() -> FFMpegDecoderOption:
@@ -5552,7 +5552,7 @@ def pcm_f32be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_f32le() -> FFMpegDecoderOption:
@@ -5563,7 +5563,7 @@ def pcm_f32le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_f64be() -> FFMpegDecoderOption:
@@ -5574,7 +5574,7 @@ def pcm_f64be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_f64le() -> FFMpegDecoderOption:
@@ -5585,7 +5585,7 @@ def pcm_f64le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_lxf() -> FFMpegDecoderOption:
@@ -5596,7 +5596,7 @@ def pcm_lxf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_mulaw() -> FFMpegDecoderOption:
@@ -5607,7 +5607,7 @@ def pcm_mulaw() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s16be() -> FFMpegDecoderOption:
@@ -5618,7 +5618,7 @@ def pcm_s16be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s16be_planar() -> FFMpegDecoderOption:
@@ -5629,7 +5629,7 @@ def pcm_s16be_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s16le() -> FFMpegDecoderOption:
@@ -5640,7 +5640,7 @@ def pcm_s16le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s16le_planar() -> FFMpegDecoderOption:
@@ -5651,7 +5651,7 @@ def pcm_s16le_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s24be() -> FFMpegDecoderOption:
@@ -5662,7 +5662,7 @@ def pcm_s24be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s24daud() -> FFMpegDecoderOption:
@@ -5673,7 +5673,7 @@ def pcm_s24daud() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s24le() -> FFMpegDecoderOption:
@@ -5684,7 +5684,7 @@ def pcm_s24le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s24le_planar() -> FFMpegDecoderOption:
@@ -5695,7 +5695,7 @@ def pcm_s24le_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s32be() -> FFMpegDecoderOption:
@@ -5706,7 +5706,7 @@ def pcm_s32be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s32le() -> FFMpegDecoderOption:
@@ -5717,7 +5717,7 @@ def pcm_s32le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s32le_planar() -> FFMpegDecoderOption:
@@ -5728,7 +5728,7 @@ def pcm_s32le_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s64be() -> FFMpegDecoderOption:
@@ -5739,7 +5739,7 @@ def pcm_s64be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s64le() -> FFMpegDecoderOption:
@@ -5750,7 +5750,7 @@ def pcm_s64le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s8() -> FFMpegDecoderOption:
@@ -5761,7 +5761,7 @@ def pcm_s8() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_s8_planar() -> FFMpegDecoderOption:
@@ -5772,7 +5772,7 @@ def pcm_s8_planar() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_sga() -> FFMpegDecoderOption:
@@ -5783,7 +5783,7 @@ def pcm_sga() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u16be() -> FFMpegDecoderOption:
@@ -5794,7 +5794,7 @@ def pcm_u16be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u16le() -> FFMpegDecoderOption:
@@ -5805,7 +5805,7 @@ def pcm_u16le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u24be() -> FFMpegDecoderOption:
@@ -5816,7 +5816,7 @@ def pcm_u24be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u24le() -> FFMpegDecoderOption:
@@ -5827,7 +5827,7 @@ def pcm_u24le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u32be() -> FFMpegDecoderOption:
@@ -5838,7 +5838,7 @@ def pcm_u32be() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u32le() -> FFMpegDecoderOption:
@@ -5849,7 +5849,7 @@ def pcm_u32le() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_u8() -> FFMpegDecoderOption:
@@ -5860,7 +5860,7 @@ def pcm_u8() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pcm_vidc() -> FFMpegDecoderOption:
@@ -5871,7 +5871,7 @@ def pcm_vidc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qcelp() -> FFMpegDecoderOption:
@@ -5882,7 +5882,7 @@ def qcelp() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qdm2() -> FFMpegDecoderOption:
@@ -5893,7 +5893,7 @@ def qdm2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def qdmc() -> FFMpegDecoderOption:
@@ -5904,7 +5904,7 @@ def qdmc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def real_144() -> FFMpegDecoderOption:
@@ -5915,7 +5915,7 @@ def real_144() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def real_288() -> FFMpegDecoderOption:
@@ -5926,7 +5926,7 @@ def real_288() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ralf() -> FFMpegDecoderOption:
@@ -5937,7 +5937,7 @@ def ralf() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def rka() -> FFMpegDecoderOption:
@@ -5948,7 +5948,7 @@ def rka() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def roq_dpcm() -> FFMpegDecoderOption:
@@ -5959,7 +5959,7 @@ def roq_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def s302m(
@@ -5977,7 +5977,7 @@ def s302m(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "non_pcm_mode": non_pcm_mode,
             }
@@ -5993,7 +5993,7 @@ def sbc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sdx2_dpcm() -> FFMpegDecoderOption:
@@ -6004,7 +6004,7 @@ def sdx2_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def shorten() -> FFMpegDecoderOption:
@@ -6015,7 +6015,7 @@ def shorten() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sipr() -> FFMpegDecoderOption:
@@ -6026,7 +6026,7 @@ def sipr() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def siren() -> FFMpegDecoderOption:
@@ -6037,7 +6037,7 @@ def siren() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def smackaud() -> FFMpegDecoderOption:
@@ -6048,7 +6048,7 @@ def smackaud() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sol_dpcm() -> FFMpegDecoderOption:
@@ -6059,7 +6059,7 @@ def sol_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sonic() -> FFMpegDecoderOption:
@@ -6070,7 +6070,7 @@ def sonic() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def speex() -> FFMpegDecoderOption:
@@ -6081,7 +6081,7 @@ def speex() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libspeex() -> FFMpegDecoderOption:
@@ -6092,7 +6092,7 @@ def libspeex() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def tak() -> FFMpegDecoderOption:
@@ -6103,7 +6103,7 @@ def tak() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def truehd(
@@ -6119,7 +6119,7 @@ def truehd(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "downmix": downmix,
             }
@@ -6135,7 +6135,7 @@ def truespeech() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def tta(
@@ -6151,7 +6151,7 @@ def tta(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "password": password,
             }
@@ -6167,7 +6167,7 @@ def twinvq() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vmdaudio() -> FFMpegDecoderOption:
@@ -6178,7 +6178,7 @@ def vmdaudio() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def vorbis() -> FFMpegDecoderOption:
@@ -6189,7 +6189,7 @@ def vorbis() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def libvorbis() -> FFMpegDecoderOption:
@@ -6200,7 +6200,7 @@ def libvorbis() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wady_dpcm() -> FFMpegDecoderOption:
@@ -6211,7 +6211,7 @@ def wady_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wavarc() -> FFMpegDecoderOption:
@@ -6222,7 +6222,7 @@ def wavarc() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wavesynth() -> FFMpegDecoderOption:
@@ -6233,7 +6233,7 @@ def wavesynth() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wavpack() -> FFMpegDecoderOption:
@@ -6244,7 +6244,7 @@ def wavpack() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ws_snd1() -> FFMpegDecoderOption:
@@ -6255,7 +6255,7 @@ def ws_snd1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmalossless() -> FFMpegDecoderOption:
@@ -6266,7 +6266,7 @@ def wmalossless() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmapro() -> FFMpegDecoderOption:
@@ -6277,7 +6277,7 @@ def wmapro() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmav1() -> FFMpegDecoderOption:
@@ -6288,7 +6288,7 @@ def wmav1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmav2() -> FFMpegDecoderOption:
@@ -6299,7 +6299,7 @@ def wmav2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def wmavoice() -> FFMpegDecoderOption:
@@ -6310,7 +6310,7 @@ def wmavoice() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xan_dpcm() -> FFMpegDecoderOption:
@@ -6321,7 +6321,7 @@ def xan_dpcm() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xma1() -> FFMpegDecoderOption:
@@ -6332,7 +6332,7 @@ def xma1() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xma2() -> FFMpegDecoderOption:
@@ -6343,7 +6343,7 @@ def xma2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ssa() -> FFMpegDecoderOption:
@@ -6354,7 +6354,7 @@ def ssa() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def ass() -> FFMpegDecoderOption:
@@ -6365,7 +6365,7 @@ def ass() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def dvbsub(
@@ -6385,7 +6385,7 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "compute_edt": compute_edt,
                 "compute_clut": compute_clut,
@@ -6426,7 +6426,7 @@ def libzvbi_teletextdec(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "txt_page": txt_page,
                 "txt_default_region": txt_default_region,
@@ -6460,7 +6460,7 @@ def dvdsub(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "palette": palette,
                 "ifo_palette": ifo_palette,
@@ -6487,7 +6487,7 @@ def cc_dec(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "real_time": real_time,
                 "real_time_latency_msec": real_time_latency_msec,
@@ -6510,7 +6510,7 @@ def pgssub(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "forced_subs_only": forced_subs_only,
             }
@@ -6526,7 +6526,7 @@ def jacosub() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def microdvd() -> FFMpegDecoderOption:
@@ -6537,7 +6537,7 @@ def microdvd() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def mov_text(
@@ -6555,7 +6555,7 @@ def mov_text(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "width": width,
                 "height": height,
@@ -6572,7 +6572,7 @@ def mpl2() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def pjs(
@@ -6588,7 +6588,7 @@ def pjs(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "keep_ass_markup": keep_ass_markup,
             }
@@ -6604,7 +6604,7 @@ def realtext() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def sami() -> FFMpegDecoderOption:
@@ -6615,7 +6615,7 @@ def sami() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def stl(
@@ -6631,7 +6631,7 @@ def stl(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "keep_ass_markup": keep_ass_markup,
             }
@@ -6647,7 +6647,7 @@ def srt() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def subrip() -> FFMpegDecoderOption:
@@ -6658,7 +6658,7 @@ def subrip() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def subviewer() -> FFMpegDecoderOption:
@@ -6669,7 +6669,7 @@ def subviewer() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def subviewer1(
@@ -6685,7 +6685,7 @@ def subviewer1(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "keep_ass_markup": keep_ass_markup,
             }
@@ -6706,7 +6706,7 @@ def text(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "keep_ass_markup": keep_ass_markup,
             }
@@ -6727,7 +6727,7 @@ def vplayer(
         the set codec options
     """
     return FFMpegDecoderOption(
-        kwargs=merge(
+        merge(
             {
                 "keep_ass_markup": keep_ass_markup,
             }
@@ -6743,7 +6743,7 @@ def webvtt() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))
 
 
 def xsub() -> FFMpegDecoderOption:
@@ -6754,4 +6754,4 @@ def xsub() -> FFMpegDecoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({}))
+    return FFMpegDecoderOption(merge({}))

--- a/src/ffmpeg/codecs/encoders.py
+++ b/src/ffmpeg/codecs/encoders.py
@@ -13,7 +13,7 @@ def a64multi() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def a64multi5() -> FFMpegEncoderOption:
@@ -24,7 +24,7 @@ def a64multi5() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def alias_pix() -> FFMpegEncoderOption:
@@ -35,7 +35,7 @@ def alias_pix() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def amv(
@@ -113,7 +113,7 @@ def amv(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -160,7 +160,7 @@ def apng(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dpi": dpi,
                 "dpm": dpm,
@@ -178,7 +178,7 @@ def asv1() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def asv2() -> FFMpegEncoderOption:
@@ -189,7 +189,7 @@ def asv2() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def librav1e(
@@ -215,7 +215,7 @@ def librav1e(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "qp": qp,
                 "speed": speed,
@@ -259,7 +259,7 @@ def libsvtav1(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "hielevel": hielevel,
                 "la_depth": la_depth,
@@ -403,7 +403,7 @@ def av1_nvenc(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "preset": preset,
                 "tune": tune,
@@ -501,7 +501,7 @@ def av1_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -527,7 +527,7 @@ def avrp() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def avui() -> FFMpegEncoderOption:
@@ -538,7 +538,7 @@ def avui() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def ayuv() -> FFMpegEncoderOption:
@@ -549,7 +549,7 @@ def ayuv() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def bitpacked() -> FFMpegEncoderOption:
@@ -560,7 +560,7 @@ def bitpacked() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def bmp() -> FFMpegEncoderOption:
@@ -571,7 +571,7 @@ def bmp() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def cfhd(
@@ -603,7 +603,7 @@ def cfhd(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "quality": quality,
             }
@@ -632,7 +632,7 @@ def cinepak(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "max_extra_cb_iterations": max_extra_cb_iterations,
                 "skip_empty_cb": skip_empty_cb,
@@ -657,7 +657,7 @@ def cljr(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dither_type": dither_type,
             }
@@ -688,7 +688,7 @@ def vc2(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "tolerance": tolerance,
                 "slice_width": slice_width,
@@ -722,7 +722,7 @@ def dnxhd(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "nitris_compat": nitris_compat,
                 "ibias": ibias,
@@ -740,7 +740,7 @@ def dpx() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def dvvideo(
@@ -756,7 +756,7 @@ def dvvideo(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "quant_deadzone": quant_deadzone,
             }
@@ -781,7 +781,7 @@ def exr(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "compression": compression,
                 "format": format,
@@ -808,7 +808,7 @@ def ffv1(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "slicecrc": slicecrc,
                 "coder": coder,
@@ -835,7 +835,7 @@ def ffvhuff(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "non_deterministic": non_deterministic,
                 "pred": pred,
@@ -853,7 +853,7 @@ def fits() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def flashsv() -> FFMpegEncoderOption:
@@ -864,7 +864,7 @@ def flashsv() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def flashsv2() -> FFMpegEncoderOption:
@@ -875,7 +875,7 @@ def flashsv2() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def flv(
@@ -957,7 +957,7 @@ def flv(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -1006,7 +1006,7 @@ def gif(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "gifflags": gifflags,
                 "gifimage": gifimage,
@@ -1095,7 +1095,7 @@ def h261(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -1210,7 +1210,7 @@ def h263(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "obmc": obmc,
                 "mb_info": mb_info,
@@ -1259,7 +1259,7 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -1355,7 +1355,7 @@ def h263p(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "umv": umv,
                 "aiv": aiv,
@@ -1498,7 +1498,7 @@ def libx264(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "preset": preset,
                 "tune": tune,
@@ -1659,7 +1659,7 @@ def libx264rgb(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "preset": preset,
                 "tune": tune,
@@ -1877,7 +1877,7 @@ def h264_nvenc(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "preset": preset,
                 "tune": tune,
@@ -1942,7 +1942,7 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -2014,7 +2014,7 @@ def h264_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -2051,7 +2051,7 @@ def hap(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "format": format,
                 "chunks": chunks,
@@ -2069,7 +2069,7 @@ def hdr() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libx265(
@@ -2101,7 +2101,7 @@ def libx265(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "crf": crf,
                 "qp": qp,
@@ -2272,7 +2272,7 @@ def hevc_nvenc(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "preset": preset,
                 "tune": tune,
@@ -2337,7 +2337,7 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -2389,7 +2389,7 @@ def hevc_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -2424,7 +2424,7 @@ def huffyuv(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "non_deterministic": non_deterministic,
                 "pred": pred,
@@ -2460,7 +2460,7 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "format": format,
                 "tile_width": tile_width,
@@ -2502,7 +2502,7 @@ def libopenjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "format": format,
                 "profile": profile,
@@ -2530,7 +2530,7 @@ def jpegls(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "pred": pred,
             }
@@ -2555,7 +2555,7 @@ def libjxl(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "effort": effort,
                 "distance": distance,
@@ -2578,7 +2578,7 @@ def ljpeg(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "pred": pred,
             }
@@ -2599,7 +2599,7 @@ def magicyuv(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "pred": pred,
             }
@@ -2682,7 +2682,7 @@ def mjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -2737,7 +2737,7 @@ def mjpeg_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -2844,7 +2844,7 @@ def mpeg1video(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "gop_timecode": gop_timecode,
                 "drop_frame_timecode": drop_frame_timecode,
@@ -2990,7 +2990,7 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "gop_timecode": gop_timecode,
                 "drop_frame_timecode": drop_frame_timecode,
@@ -3064,7 +3064,7 @@ def mpeg2_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -3170,7 +3170,7 @@ def mpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "data_partitioning": data_partitioning,
                 "alternate_scan": alternate_scan,
@@ -3233,7 +3233,7 @@ def libxvid(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lumi_aq": lumi_aq,
                 "variance_aq": variance_aq,
@@ -3262,7 +3262,7 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -3350,7 +3350,7 @@ def msmpeg4v2(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -3461,7 +3461,7 @@ def msmpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -3501,7 +3501,7 @@ def msrle() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def msvideo1() -> FFMpegEncoderOption:
@@ -3512,7 +3512,7 @@ def msvideo1() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pam() -> FFMpegEncoderOption:
@@ -3523,7 +3523,7 @@ def pam() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pbm() -> FFMpegEncoderOption:
@@ -3534,7 +3534,7 @@ def pbm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcx() -> FFMpegEncoderOption:
@@ -3545,7 +3545,7 @@ def pcx() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pfm() -> FFMpegEncoderOption:
@@ -3556,7 +3556,7 @@ def pfm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pgm() -> FFMpegEncoderOption:
@@ -3567,7 +3567,7 @@ def pgm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pgmyuv() -> FFMpegEncoderOption:
@@ -3578,7 +3578,7 @@ def pgmyuv() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def phm() -> FFMpegEncoderOption:
@@ -3589,7 +3589,7 @@ def phm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def png(
@@ -3609,7 +3609,7 @@ def png(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dpi": dpi,
                 "dpm": dpm,
@@ -3627,7 +3627,7 @@ def ppm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def prores(
@@ -3643,7 +3643,7 @@ def prores(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "vendor": vendor,
             }
@@ -3664,7 +3664,7 @@ def prores_aw(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "vendor": vendor,
             }
@@ -3699,7 +3699,7 @@ def prores_ks(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mbs_per_slice": mbs_per_slice,
                 "profile": profile,
@@ -3720,7 +3720,7 @@ def qoi() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def qtrle() -> FFMpegEncoderOption:
@@ -3731,7 +3731,7 @@ def qtrle() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def r10k() -> FFMpegEncoderOption:
@@ -3742,7 +3742,7 @@ def r10k() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def r210() -> FFMpegEncoderOption:
@@ -3753,7 +3753,7 @@ def r210() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def rawvideo() -> FFMpegEncoderOption:
@@ -3764,7 +3764,7 @@ def rawvideo() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def roqvideo(
@@ -3780,7 +3780,7 @@ def roqvideo(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "quake3_compat": quake3_compat,
             }
@@ -3805,7 +3805,7 @@ def rpza(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "skip_frame_thresh": skip_frame_thresh,
                 "continue_one_color_thresh": continue_one_color_thresh,
@@ -3894,7 +3894,7 @@ def rv10(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -4005,7 +4005,7 @@ def rv20(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -4050,7 +4050,7 @@ def sgi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "rle": rle,
             }
@@ -4066,7 +4066,7 @@ def smc() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def snow(
@@ -4096,7 +4096,7 @@ def snow(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "motion_est": motion_est,
                 "memc_only": memc_only,
@@ -4190,7 +4190,7 @@ def speedhq(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -4235,7 +4235,7 @@ def sunrast(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "rle": rle,
             }
@@ -4256,7 +4256,7 @@ def svq1(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "motion-est": motion_est,
             }
@@ -4277,7 +4277,7 @@ def targa(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "rle": rle,
             }
@@ -4293,7 +4293,7 @@ def libtheora() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def tiff(
@@ -4311,7 +4311,7 @@ def tiff(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dpi": dpi,
                 "compression_algo": compression_algo,
@@ -4333,7 +4333,7 @@ def utvideo(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "pred": pred,
             }
@@ -4349,7 +4349,7 @@ def v210() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def v308() -> FFMpegEncoderOption:
@@ -4360,7 +4360,7 @@ def v308() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def v408() -> FFMpegEncoderOption:
@@ -4371,7 +4371,7 @@ def v408() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def v410() -> FFMpegEncoderOption:
@@ -4382,7 +4382,7 @@ def v410() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def vbn(
@@ -4398,7 +4398,7 @@ def vbn(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "format": format,
             }
@@ -4414,7 +4414,7 @@ def vnull() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libvpx(
@@ -4474,7 +4474,7 @@ def libvpx(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lag-in-frames": lag_in_frames,
                 "arnr-maxframes": arnr_maxframes,
@@ -4519,7 +4519,7 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "num_output_buffers": num_output_buffers,
                 "num_capture_buffers": num_capture_buffers,
@@ -4557,7 +4557,7 @@ def vp8_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -4601,7 +4601,7 @@ def vp9_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "low_power": low_power,
                 "idr_interval": idr_interval,
@@ -4624,7 +4624,7 @@ def wbmp() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libwebp_anim(
@@ -4650,7 +4650,7 @@ def libwebp_anim(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lossless": lossless,
                 "preset": preset,
@@ -4685,7 +4685,7 @@ def libwebp(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lossless": lossless,
                 "preset": preset,
@@ -4776,7 +4776,7 @@ def wmv1(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -4887,7 +4887,7 @@ def wmv2(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mpv_flags": mpv_flags,
                 "luma_elim_threshold": luma_elim_threshold,
@@ -4927,7 +4927,7 @@ def wrapped_avframe() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def xbm() -> FFMpegEncoderOption:
@@ -4938,7 +4938,7 @@ def xbm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def xface() -> FFMpegEncoderOption:
@@ -4949,7 +4949,7 @@ def xface() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def xwd() -> FFMpegEncoderOption:
@@ -4960,7 +4960,7 @@ def xwd() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def y41p() -> FFMpegEncoderOption:
@@ -4971,7 +4971,7 @@ def y41p() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def yuv4() -> FFMpegEncoderOption:
@@ -4982,7 +4982,7 @@ def yuv4() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def zlib() -> FFMpegEncoderOption:
@@ -4993,7 +4993,7 @@ def zlib() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def zmbv() -> FFMpegEncoderOption:
@@ -5004,7 +5004,7 @@ def zmbv() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def aac(
@@ -5034,7 +5034,7 @@ def aac(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "aac_coder": aac_coder,
                 "aac_ms": aac_ms,
@@ -5100,7 +5100,7 @@ def ac3(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "center_mixlev": center_mixlev,
                 "surround_mixlev": surround_mixlev,
@@ -5178,7 +5178,7 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "center_mixlev": center_mixlev,
                 "surround_mixlev": surround_mixlev,
@@ -5213,7 +5213,7 @@ def adpcm_adx() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def adpcm_argo(
@@ -5229,7 +5229,7 @@ def adpcm_argo(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5245,7 +5245,7 @@ def g722() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def g726(
@@ -5261,7 +5261,7 @@ def g726(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "code_size": code_size,
             }
@@ -5282,7 +5282,7 @@ def g726le(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "code_size": code_size,
             }
@@ -5303,7 +5303,7 @@ def adpcm_ima_alp(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5324,7 +5324,7 @@ def adpcm_ima_amv(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5345,7 +5345,7 @@ def adpcm_ima_apm(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5366,7 +5366,7 @@ def adpcm_ima_qt(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5387,7 +5387,7 @@ def adpcm_ima_ssi(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5408,7 +5408,7 @@ def adpcm_ima_wav(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5429,7 +5429,7 @@ def adpcm_ima_ws(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5450,7 +5450,7 @@ def adpcm_ms(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5471,7 +5471,7 @@ def adpcm_swf(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5492,7 +5492,7 @@ def adpcm_yamaha(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "block_size": block_size,
             }
@@ -5515,7 +5515,7 @@ def alac(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "min_prediction_order": min_prediction_order,
                 "max_prediction_order": max_prediction_order,
@@ -5532,7 +5532,7 @@ def anull() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def aptx() -> FFMpegEncoderOption:
@@ -5543,7 +5543,7 @@ def aptx() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def aptx_hd() -> FFMpegEncoderOption:
@@ -5554,7 +5554,7 @@ def aptx_hd() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libcodec2(
@@ -5574,7 +5574,7 @@ def libcodec2(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mode": mode,
             }
@@ -5590,7 +5590,7 @@ def comfortnoise() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def dfpwm() -> FFMpegEncoderOption:
@@ -5601,7 +5601,7 @@ def dfpwm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def dca(
@@ -5617,7 +5617,7 @@ def dca(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "dca_adpcm": dca_adpcm,
             }
@@ -5672,7 +5672,7 @@ def eac3(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mixing_level": mixing_level,
                 "room_type": room_type,
@@ -5730,7 +5730,7 @@ def flac(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "lpc_coeff_precision": lpc_coeff_precision,
                 "lpc_type": lpc_type,
@@ -5754,7 +5754,7 @@ def g723_1() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libgsm() -> FFMpegEncoderOption:
@@ -5765,7 +5765,7 @@ def libgsm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libgsm_ms() -> FFMpegEncoderOption:
@@ -5776,7 +5776,7 @@ def libgsm_ms() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def mlp(
@@ -5804,7 +5804,7 @@ def mlp(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "max_interval": max_interval,
                 "lpc_coeff_precision": lpc_coeff_precision,
@@ -5826,7 +5826,7 @@ def mp2() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def mp2fixed() -> FFMpegEncoderOption:
@@ -5837,7 +5837,7 @@ def mp2fixed() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libtwolame(
@@ -5867,7 +5867,7 @@ def libtwolame(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "mode": mode,
                 "psymodel": psymodel,
@@ -5902,7 +5902,7 @@ def libmp3lame(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "reservoir": reservoir,
                 "joint_stereo": joint_stereo,
@@ -5922,7 +5922,7 @@ def libshine() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def nellymoser() -> FFMpegEncoderOption:
@@ -5933,7 +5933,7 @@ def nellymoser() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def opus(
@@ -5951,7 +5951,7 @@ def opus(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "opus_delay": opus_delay,
                 "apply_phase_inv": apply_phase_inv,
@@ -5985,7 +5985,7 @@ def libopus(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "application": application,
                 "frame_duration": frame_duration,
@@ -6007,7 +6007,7 @@ def pcm_alaw() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_bluray() -> FFMpegEncoderOption:
@@ -6018,7 +6018,7 @@ def pcm_bluray() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_dvd() -> FFMpegEncoderOption:
@@ -6029,7 +6029,7 @@ def pcm_dvd() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_f32be() -> FFMpegEncoderOption:
@@ -6040,7 +6040,7 @@ def pcm_f32be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_f32le() -> FFMpegEncoderOption:
@@ -6051,7 +6051,7 @@ def pcm_f32le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_f64be() -> FFMpegEncoderOption:
@@ -6062,7 +6062,7 @@ def pcm_f64be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_f64le() -> FFMpegEncoderOption:
@@ -6073,7 +6073,7 @@ def pcm_f64le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_mulaw() -> FFMpegEncoderOption:
@@ -6084,7 +6084,7 @@ def pcm_mulaw() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s16be() -> FFMpegEncoderOption:
@@ -6095,7 +6095,7 @@ def pcm_s16be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s16be_planar() -> FFMpegEncoderOption:
@@ -6106,7 +6106,7 @@ def pcm_s16be_planar() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s16le() -> FFMpegEncoderOption:
@@ -6117,7 +6117,7 @@ def pcm_s16le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s16le_planar() -> FFMpegEncoderOption:
@@ -6128,7 +6128,7 @@ def pcm_s16le_planar() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s24be() -> FFMpegEncoderOption:
@@ -6139,7 +6139,7 @@ def pcm_s24be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s24daud() -> FFMpegEncoderOption:
@@ -6150,7 +6150,7 @@ def pcm_s24daud() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s24le() -> FFMpegEncoderOption:
@@ -6161,7 +6161,7 @@ def pcm_s24le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s24le_planar() -> FFMpegEncoderOption:
@@ -6172,7 +6172,7 @@ def pcm_s24le_planar() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s32be() -> FFMpegEncoderOption:
@@ -6183,7 +6183,7 @@ def pcm_s32be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s32le() -> FFMpegEncoderOption:
@@ -6194,7 +6194,7 @@ def pcm_s32le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s32le_planar() -> FFMpegEncoderOption:
@@ -6205,7 +6205,7 @@ def pcm_s32le_planar() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s64be() -> FFMpegEncoderOption:
@@ -6216,7 +6216,7 @@ def pcm_s64be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s64le() -> FFMpegEncoderOption:
@@ -6227,7 +6227,7 @@ def pcm_s64le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s8() -> FFMpegEncoderOption:
@@ -6238,7 +6238,7 @@ def pcm_s8() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_s8_planar() -> FFMpegEncoderOption:
@@ -6249,7 +6249,7 @@ def pcm_s8_planar() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u16be() -> FFMpegEncoderOption:
@@ -6260,7 +6260,7 @@ def pcm_u16be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u16le() -> FFMpegEncoderOption:
@@ -6271,7 +6271,7 @@ def pcm_u16le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u24be() -> FFMpegEncoderOption:
@@ -6282,7 +6282,7 @@ def pcm_u24be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u24le() -> FFMpegEncoderOption:
@@ -6293,7 +6293,7 @@ def pcm_u24le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u32be() -> FFMpegEncoderOption:
@@ -6304,7 +6304,7 @@ def pcm_u32be() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u32le() -> FFMpegEncoderOption:
@@ -6315,7 +6315,7 @@ def pcm_u32le() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_u8() -> FFMpegEncoderOption:
@@ -6326,7 +6326,7 @@ def pcm_u8() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def pcm_vidc() -> FFMpegEncoderOption:
@@ -6337,7 +6337,7 @@ def pcm_vidc() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def real_144() -> FFMpegEncoderOption:
@@ -6348,7 +6348,7 @@ def real_144() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def roq_dpcm() -> FFMpegEncoderOption:
@@ -6359,7 +6359,7 @@ def roq_dpcm() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def s302m() -> FFMpegEncoderOption:
@@ -6370,7 +6370,7 @@ def s302m() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def sbc(
@@ -6388,7 +6388,7 @@ def sbc(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "sbc_delay": sbc_delay,
                 "msbc": msbc,
@@ -6405,7 +6405,7 @@ def sonic() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def sonicls() -> FFMpegEncoderOption:
@@ -6416,7 +6416,7 @@ def sonicls() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libspeex(
@@ -6440,7 +6440,7 @@ def libspeex(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "abr": abr,
                 "cbr_quality": cbr_quality,
@@ -6477,7 +6477,7 @@ def truehd(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "max_interval": max_interval,
                 "lpc_coeff_precision": lpc_coeff_precision,
@@ -6499,7 +6499,7 @@ def tta() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def vorbis() -> FFMpegEncoderOption:
@@ -6510,7 +6510,7 @@ def vorbis() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def libvorbis(
@@ -6526,7 +6526,7 @@ def libvorbis(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "iblock": iblock,
             }
@@ -6549,7 +6549,7 @@ def wavpack(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "joint_stereo": joint_stereo,
                 "optimize_mono": optimize_mono,
@@ -6566,7 +6566,7 @@ def wmav1() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def wmav2() -> FFMpegEncoderOption:
@@ -6577,7 +6577,7 @@ def wmav2() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def ssa() -> FFMpegEncoderOption:
@@ -6588,7 +6588,7 @@ def ssa() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def ass() -> FFMpegEncoderOption:
@@ -6599,7 +6599,7 @@ def ass() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def dvbsub() -> FFMpegEncoderOption:
@@ -6610,7 +6610,7 @@ def dvbsub() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def dvdsub(
@@ -6628,7 +6628,7 @@ def dvdsub(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "palette": palette,
                 "even_rows_fix": even_rows_fix,
@@ -6650,7 +6650,7 @@ def mov_text(
         the set codec options
     """
     return FFMpegEncoderOption(
-        kwargs=merge(
+        merge(
             {
                 "height": height,
             }
@@ -6666,7 +6666,7 @@ def srt() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def subrip() -> FFMpegEncoderOption:
@@ -6677,7 +6677,7 @@ def subrip() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def text() -> FFMpegEncoderOption:
@@ -6688,7 +6688,7 @@ def text() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def ttml() -> FFMpegEncoderOption:
@@ -6699,7 +6699,7 @@ def ttml() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def webvtt() -> FFMpegEncoderOption:
@@ -6710,7 +6710,7 @@ def webvtt() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))
 
 
 def xsub() -> FFMpegEncoderOption:
@@ -6721,4 +6721,4 @@ def xsub() -> FFMpegEncoderOption:
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({}))
+    return FFMpegEncoderOption(merge({}))

--- a/src/ffmpeg/codecs/schema.py
+++ b/src/ffmpeg/codecs/schema.py
@@ -1,11 +1,7 @@
-from dataclasses import dataclass
-
 from ..schema import FFMpegOptionGroup
 
 
-@dataclass(frozen=True, kw_only=True)
 class FFMpegEncoderOption(FFMpegOptionGroup): ...
 
 
-@dataclass(frozen=True, kw_only=True)
 class FFMpegDecoderOption(FFMpegOptionGroup): ...

--- a/src/ffmpeg/dag/io/_input.py
+++ b/src/ffmpeg/dag/io/_input.py
@@ -205,8 +205,8 @@ def input(
                 "dn": dn,
                 "top": top,
             },
-            decoder_options.kwargs if decoder_options else {},
-            demuxer_options.kwargs if demuxer_options else {},
+            decoder_options,
+            demuxer_options,
             extra_options,
         ),
     ).stream()

--- a/src/ffmpeg/dag/io/_output.py
+++ b/src/ffmpeg/dag/io/_output.py
@@ -329,8 +329,8 @@ def output(
                 "dn": dn,
                 "top": top,
             },
-            encoder_options.kwargs if encoder_options else {},
-            muxer_options.kwargs if muxer_options else {},
+            encoder_options,
+            muxer_options,
             extra_options,
         ),
     ).stream()

--- a/src/ffmpeg/dag/io/output_args.py
+++ b/src/ffmpeg/dag/io/output_args.py
@@ -341,8 +341,8 @@ class OutputArgs(ABC):
                     "dn": dn,
                     "top": top,
                 },
-                encoder_options.kwargs if encoder_options else {},
-                muxer_options.kwargs if muxer_options else {},
+                encoder_options,
+                muxer_options,
                 extra_options,
             ),
         ).stream()

--- a/src/ffmpeg/formats/demuxers.py
+++ b/src/ffmpeg/formats/demuxers.py
@@ -13,7 +13,7 @@ def _3dostr() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def _4xm() -> FFMpegDemuxerOption:
@@ -24,7 +24,7 @@ def _4xm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def aa(
@@ -40,7 +40,7 @@ def aa(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "aa_fixed_key": aa_fixed_key,
             }
@@ -56,7 +56,7 @@ def aac() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def aax() -> FFMpegDemuxerOption:
@@ -67,7 +67,7 @@ def aax() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ac3(
@@ -83,7 +83,7 @@ def ac3(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -99,7 +99,7 @@ def ac4() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ace() -> FFMpegDemuxerOption:
@@ -110,7 +110,7 @@ def ace() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def acm(
@@ -126,7 +126,7 @@ def acm(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -142,7 +142,7 @@ def act() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def adf(
@@ -162,7 +162,7 @@ def adf(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "linespeed": linespeed,
                 "video_size": video_size,
@@ -180,7 +180,7 @@ def adp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ads() -> FFMpegDemuxerOption:
@@ -191,7 +191,7 @@ def ads() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def adx() -> FFMpegDemuxerOption:
@@ -202,7 +202,7 @@ def adx() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def aea() -> FFMpegDemuxerOption:
@@ -213,7 +213,7 @@ def aea() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def afc() -> FFMpegDemuxerOption:
@@ -224,7 +224,7 @@ def afc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def aiff() -> FFMpegDemuxerOption:
@@ -235,7 +235,7 @@ def aiff() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def aix() -> FFMpegDemuxerOption:
@@ -246,7 +246,7 @@ def aix() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def alaw(
@@ -266,7 +266,7 @@ def alaw(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -307,7 +307,7 @@ def alias_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "pattern_type": pattern_type,
                 "start_number": start_number,
@@ -331,7 +331,7 @@ def alp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def alsa(
@@ -349,7 +349,7 @@ def alsa(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -371,7 +371,7 @@ def amr(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -392,7 +392,7 @@ def amrnb(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -413,7 +413,7 @@ def amrwb(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -429,7 +429,7 @@ def anm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def apac(
@@ -445,7 +445,7 @@ def apac(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -461,7 +461,7 @@ def apc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ape() -> FFMpegDemuxerOption:
@@ -472,7 +472,7 @@ def ape() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def apm() -> FFMpegDemuxerOption:
@@ -483,7 +483,7 @@ def apm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def apng(
@@ -503,7 +503,7 @@ def apng(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "ignore_loop": ignore_loop,
                 "max_fps": max_fps,
@@ -526,7 +526,7 @@ def aptx(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
             }
@@ -547,7 +547,7 @@ def aptx_hd(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
             }
@@ -568,7 +568,7 @@ def aqtitle(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "subfps": subfps,
             }
@@ -584,7 +584,7 @@ def argo_asf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def argo_brp() -> FFMpegDemuxerOption:
@@ -595,7 +595,7 @@ def argo_brp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def argo_cvg() -> FFMpegDemuxerOption:
@@ -606,7 +606,7 @@ def argo_cvg() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def asf(
@@ -624,7 +624,7 @@ def asf(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "no_resync_search": no_resync_search,
                 "export_xmp": export_xmp,
@@ -641,7 +641,7 @@ def asf_o() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ass() -> FFMpegDemuxerOption:
@@ -652,7 +652,7 @@ def ass() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ast() -> FFMpegDemuxerOption:
@@ -663,7 +663,7 @@ def ast() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def au() -> FFMpegDemuxerOption:
@@ -674,7 +674,7 @@ def au() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def av1(
@@ -690,7 +690,7 @@ def av1(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
             }
@@ -711,7 +711,7 @@ def avi(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "use_odml": use_odml,
             }
@@ -727,7 +727,7 @@ def avr() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def avs() -> FFMpegDemuxerOption:
@@ -738,7 +738,7 @@ def avs() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def avs2(
@@ -756,7 +756,7 @@ def avs2(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -780,7 +780,7 @@ def avs3(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -797,7 +797,7 @@ def bethsoftvid() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def bfi() -> FFMpegDemuxerOption:
@@ -808,7 +808,7 @@ def bfi() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def bfstm() -> FFMpegDemuxerOption:
@@ -819,7 +819,7 @@ def bfstm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def bin(
@@ -839,7 +839,7 @@ def bin(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "linespeed": linespeed,
                 "video_size": video_size,
@@ -857,7 +857,7 @@ def bink() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def binka() -> FFMpegDemuxerOption:
@@ -868,7 +868,7 @@ def binka() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def bit() -> FFMpegDemuxerOption:
@@ -879,7 +879,7 @@ def bit() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def bitpacked(
@@ -899,7 +899,7 @@ def bitpacked(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "pixel_format": pixel_format,
                 "video_size": video_size,
@@ -930,7 +930,7 @@ def bmp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -950,7 +950,7 @@ def bmv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def boa() -> FFMpegDemuxerOption:
@@ -961,7 +961,7 @@ def boa() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def bonk(
@@ -977,7 +977,7 @@ def bonk(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1016,7 +1016,7 @@ def brender_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "pattern_type": pattern_type,
                 "start_number": start_number,
@@ -1040,7 +1040,7 @@ def brstm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def c93() -> FFMpegDemuxerOption:
@@ -1051,7 +1051,7 @@ def c93() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def caf() -> FFMpegDemuxerOption:
@@ -1062,7 +1062,7 @@ def caf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def cavsvideo(
@@ -1080,7 +1080,7 @@ def cavsvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -1097,7 +1097,7 @@ def cdg() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def cdxl(
@@ -1115,7 +1115,7 @@ def cdxl(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "frame_rate": frame_rate,
@@ -1132,7 +1132,7 @@ def cine() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def codec2(
@@ -1148,7 +1148,7 @@ def codec2(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frames_per_packet": frames_per_packet,
             }
@@ -1175,7 +1175,7 @@ def codec2raw(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "mode": mode,
                 "frames_per_packet": frames_per_packet,
@@ -1201,7 +1201,7 @@ def concat(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "safe": safe,
                 "auto_convert": auto_convert,
@@ -1232,7 +1232,7 @@ def cri_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -1259,7 +1259,7 @@ def dash(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "allowed_extensions": allowed_extensions,
                 "cenc_decryption_key": cenc_decryption_key,
@@ -1281,7 +1281,7 @@ def data(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1297,7 +1297,7 @@ def daud() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dcstr() -> FFMpegDemuxerOption:
@@ -1308,7 +1308,7 @@ def dcstr() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dds_pipe(
@@ -1332,7 +1332,7 @@ def dds_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -1352,7 +1352,7 @@ def derf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dfa() -> FFMpegDemuxerOption:
@@ -1363,7 +1363,7 @@ def dfa() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dfpwm(
@@ -1383,7 +1383,7 @@ def dfpwm(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -1401,7 +1401,7 @@ def dhav() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dirac(
@@ -1419,7 +1419,7 @@ def dirac(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -1443,7 +1443,7 @@ def dnxhd(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -1473,7 +1473,7 @@ def dpx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -1493,7 +1493,7 @@ def dsf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dsicin() -> FFMpegDemuxerOption:
@@ -1504,7 +1504,7 @@ def dsicin() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dss() -> FFMpegDemuxerOption:
@@ -1515,7 +1515,7 @@ def dss() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dts(
@@ -1531,7 +1531,7 @@ def dts(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1547,7 +1547,7 @@ def dtshd() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dv() -> FFMpegDemuxerOption:
@@ -1558,7 +1558,7 @@ def dv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def dvbsub(
@@ -1574,7 +1574,7 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1595,7 +1595,7 @@ def dvbtxt(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1611,7 +1611,7 @@ def dxa() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ea(
@@ -1627,7 +1627,7 @@ def ea(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "merge_alpha": merge_alpha,
             }
@@ -1643,7 +1643,7 @@ def ea_cdata() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def eac3(
@@ -1659,7 +1659,7 @@ def eac3(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1675,7 +1675,7 @@ def epaf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def evc(
@@ -1691,7 +1691,7 @@ def evc(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
             }
@@ -1720,7 +1720,7 @@ def exr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -1749,7 +1749,7 @@ def f32be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -1776,7 +1776,7 @@ def f32le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -1803,7 +1803,7 @@ def f64be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -1830,7 +1830,7 @@ def f64le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -1853,7 +1853,7 @@ def fbdev(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
             }
@@ -1869,7 +1869,7 @@ def ffmetadata() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def film_cpk() -> FFMpegDemuxerOption:
@@ -1880,7 +1880,7 @@ def film_cpk() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def filmstrip() -> FFMpegDemuxerOption:
@@ -1891,7 +1891,7 @@ def filmstrip() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def fits(
@@ -1907,7 +1907,7 @@ def fits(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
             }
@@ -1928,7 +1928,7 @@ def flac(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -1944,7 +1944,7 @@ def flic() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def flv(
@@ -1966,7 +1966,7 @@ def flv(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "flv_metadata": flv_metadata,
                 "flv_full_metadata": flv_full_metadata,
@@ -1985,7 +1985,7 @@ def frm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def fsb() -> FFMpegDemuxerOption:
@@ -1996,7 +1996,7 @@ def fsb() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def fwse() -> FFMpegDemuxerOption:
@@ -2007,7 +2007,7 @@ def fwse() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def g722(
@@ -2023,7 +2023,7 @@ def g722(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -2039,7 +2039,7 @@ def g723_1() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def g726(
@@ -2057,7 +2057,7 @@ def g726(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "code_size": code_size,
                 "sample_rate": sample_rate,
@@ -2081,7 +2081,7 @@ def g726le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "code_size": code_size,
                 "sample_rate": sample_rate,
@@ -2103,7 +2103,7 @@ def g729(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "bit_rate": bit_rate,
             }
@@ -2119,7 +2119,7 @@ def gdv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def gem_pipe(
@@ -2143,7 +2143,7 @@ def gem_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2163,7 +2163,7 @@ def genh() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def gif(
@@ -2185,7 +2185,7 @@ def gif(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "min_delay": min_delay,
                 "max_gif_delay": max_gif_delay,
@@ -2217,7 +2217,7 @@ def gif_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2242,7 +2242,7 @@ def gsm(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
             }
@@ -2258,7 +2258,7 @@ def gxf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def h261(
@@ -2276,7 +2276,7 @@ def h261(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -2300,7 +2300,7 @@ def h263(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -2324,7 +2324,7 @@ def h264(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -2350,7 +2350,7 @@ def hca(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "hca_lowkey": hca_lowkey,
                 "hca_highkey": hca_highkey,
@@ -2368,7 +2368,7 @@ def hcom() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def hdr_pipe(
@@ -2392,7 +2392,7 @@ def hdr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2419,7 +2419,7 @@ def hevc(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -2459,7 +2459,7 @@ def hls(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "live_start_index": live_start_index,
                 "prefer_x_start": prefer_x_start,
@@ -2484,7 +2484,7 @@ def hnm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ico() -> FFMpegDemuxerOption:
@@ -2495,7 +2495,7 @@ def ico() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def idcin() -> FFMpegDemuxerOption:
@@ -2506,7 +2506,7 @@ def idcin() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def idf(
@@ -2526,7 +2526,7 @@ def idf(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "linespeed": linespeed,
                 "video_size": video_size,
@@ -2553,7 +2553,7 @@ def iec61883(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "dvtype": dvtype,
                 "dvbuffer": dvbuffer,
@@ -2571,7 +2571,7 @@ def iff() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ifv() -> FFMpegDemuxerOption:
@@ -2582,7 +2582,7 @@ def ifv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ilbc() -> FFMpegDemuxerOption:
@@ -2593,7 +2593,7 @@ def ilbc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def image2(
@@ -2627,7 +2627,7 @@ def image2(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "pattern_type": pattern_type,
                 "start_number": start_number,
@@ -2664,7 +2664,7 @@ def image2pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2689,7 +2689,7 @@ def imf(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "assetmaps": assetmaps,
             }
@@ -2712,7 +2712,7 @@ def ingenient(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -2729,7 +2729,7 @@ def ipmovie() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ipu(
@@ -2745,7 +2745,7 @@ def ipu(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -2761,7 +2761,7 @@ def ircam() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def iss() -> FFMpegDemuxerOption:
@@ -2772,7 +2772,7 @@ def iss() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def iv8() -> FFMpegDemuxerOption:
@@ -2783,7 +2783,7 @@ def iv8() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ivf() -> FFMpegDemuxerOption:
@@ -2794,7 +2794,7 @@ def ivf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ivr() -> FFMpegDemuxerOption:
@@ -2805,7 +2805,7 @@ def ivr() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def j2k_pipe(
@@ -2829,7 +2829,7 @@ def j2k_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2854,7 +2854,7 @@ def jack(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "channels": channels,
             }
@@ -2870,7 +2870,7 @@ def jacosub() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def jpeg_pipe(
@@ -2894,7 +2894,7 @@ def jpeg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2927,7 +2927,7 @@ def jpegls_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2947,7 +2947,7 @@ def jpegxl_anim() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def jpegxl_pipe(
@@ -2971,7 +2971,7 @@ def jpegxl_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -2991,7 +2991,7 @@ def jv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def kmsgrab(
@@ -3017,7 +3017,7 @@ def kmsgrab(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "device": device,
                 "format": format,
@@ -3049,7 +3049,7 @@ def kux(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "flv_metadata": flv_metadata,
                 "flv_full_metadata": flv_full_metadata,
@@ -3068,7 +3068,7 @@ def kvag() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def laf() -> FFMpegDemuxerOption:
@@ -3079,7 +3079,7 @@ def laf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def lavfi(
@@ -3099,7 +3099,7 @@ def lavfi(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "graph": graph,
                 "graph_file": graph_file,
@@ -3124,7 +3124,7 @@ def libcdio(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "speed": speed,
                 "paranoia_mode": paranoia_mode,
@@ -3150,7 +3150,7 @@ def libdc1394(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "video_size": video_size,
                 "pixel_format": pixel_format,
@@ -3177,7 +3177,7 @@ def libgme(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "track_index": track_index,
                 "sample_rate": sample_rate,
@@ -3204,7 +3204,7 @@ def libopenmpt(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "layout": layout,
@@ -3233,7 +3233,7 @@ def live_flv(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "flv_metadata": flv_metadata,
                 "flv_full_metadata": flv_full_metadata,
@@ -3252,7 +3252,7 @@ def lmlm4() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def loas(
@@ -3268,7 +3268,7 @@ def loas(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -3284,7 +3284,7 @@ def lrc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def luodat() -> FFMpegDemuxerOption:
@@ -3295,7 +3295,7 @@ def luodat() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def lvf() -> FFMpegDemuxerOption:
@@ -3306,7 +3306,7 @@ def lvf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def lxf() -> FFMpegDemuxerOption:
@@ -3317,7 +3317,7 @@ def lxf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def m4v(
@@ -3335,7 +3335,7 @@ def m4v(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -3352,7 +3352,7 @@ def mca() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mcc() -> FFMpegDemuxerOption:
@@ -3363,7 +3363,7 @@ def mcc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mgsts() -> FFMpegDemuxerOption:
@@ -3374,7 +3374,7 @@ def mgsts() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def microdvd(
@@ -3390,7 +3390,7 @@ def microdvd(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "subfps": subfps,
             }
@@ -3413,7 +3413,7 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -3437,7 +3437,7 @@ def mjpeg_2000(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -3459,7 +3459,7 @@ def mlp(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -3475,7 +3475,7 @@ def mlv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mm() -> FFMpegDemuxerOption:
@@ -3486,7 +3486,7 @@ def mm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mmf() -> FFMpegDemuxerOption:
@@ -3497,7 +3497,7 @@ def mmf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mods() -> FFMpegDemuxerOption:
@@ -3508,7 +3508,7 @@ def mods() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def moflex() -> FFMpegDemuxerOption:
@@ -3519,7 +3519,7 @@ def moflex() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mp3(
@@ -3535,7 +3535,7 @@ def mp3(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "usetoc": usetoc,
             }
@@ -3551,7 +3551,7 @@ def mpc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mpc8() -> FFMpegDemuxerOption:
@@ -3562,7 +3562,7 @@ def mpc8() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mpeg() -> FFMpegDemuxerOption:
@@ -3573,7 +3573,7 @@ def mpeg() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mpegts(
@@ -3601,7 +3601,7 @@ def mpegts(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "resync_size": resync_size,
                 "fix_teletext_pts": fix_teletext_pts,
@@ -3632,7 +3632,7 @@ def mpegtsraw(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "resync_size": resync_size,
                 "compute_pcr": compute_pcr,
@@ -3657,7 +3657,7 @@ def mpegvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -3679,7 +3679,7 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "strict_mime_boundary": strict_mime_boundary,
             }
@@ -3695,7 +3695,7 @@ def mpl2() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mpsub() -> FFMpegDemuxerOption:
@@ -3706,7 +3706,7 @@ def mpsub() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def msf() -> FFMpegDemuxerOption:
@@ -3717,7 +3717,7 @@ def msf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def msnwctcp() -> FFMpegDemuxerOption:
@@ -3728,7 +3728,7 @@ def msnwctcp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def msp() -> FFMpegDemuxerOption:
@@ -3739,7 +3739,7 @@ def msp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mtaf() -> FFMpegDemuxerOption:
@@ -3750,7 +3750,7 @@ def mtaf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mtv() -> FFMpegDemuxerOption:
@@ -3761,7 +3761,7 @@ def mtv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mulaw(
@@ -3781,7 +3781,7 @@ def mulaw(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -3799,7 +3799,7 @@ def musx() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mv() -> FFMpegDemuxerOption:
@@ -3810,7 +3810,7 @@ def mv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mvi() -> FFMpegDemuxerOption:
@@ -3821,7 +3821,7 @@ def mvi() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def mxf(
@@ -3837,7 +3837,7 @@ def mxf(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "eia608_extract": eia608_extract,
             }
@@ -3853,7 +3853,7 @@ def mxg() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def nc() -> FFMpegDemuxerOption:
@@ -3864,7 +3864,7 @@ def nc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def nistsphere() -> FFMpegDemuxerOption:
@@ -3875,7 +3875,7 @@ def nistsphere() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def nsp() -> FFMpegDemuxerOption:
@@ -3886,7 +3886,7 @@ def nsp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def nsv() -> FFMpegDemuxerOption:
@@ -3897,7 +3897,7 @@ def nsv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def nut() -> FFMpegDemuxerOption:
@@ -3908,7 +3908,7 @@ def nut() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def nuv() -> FFMpegDemuxerOption:
@@ -3919,7 +3919,7 @@ def nuv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def obu(
@@ -3935,7 +3935,7 @@ def obu(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
             }
@@ -3951,7 +3951,7 @@ def ogg() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def oma() -> FFMpegDemuxerOption:
@@ -3962,7 +3962,7 @@ def oma() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def openal(
@@ -3984,7 +3984,7 @@ def openal(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "channels": channels,
                 "sample_rate": sample_rate,
@@ -4008,7 +4008,7 @@ def osq(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -4031,7 +4031,7 @@ def oss(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -4048,7 +4048,7 @@ def paf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def pam_pipe(
@@ -4072,7 +4072,7 @@ def pam_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4105,7 +4105,7 @@ def pbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4138,7 +4138,7 @@ def pcx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4158,7 +4158,7 @@ def pdv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def pfm_pipe(
@@ -4182,7 +4182,7 @@ def pfm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4215,7 +4215,7 @@ def pgm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4248,7 +4248,7 @@ def pgmyuv_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4281,7 +4281,7 @@ def pgx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4314,7 +4314,7 @@ def phm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4347,7 +4347,7 @@ def photocd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4380,7 +4380,7 @@ def pictor_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4400,7 +4400,7 @@ def pjs() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def pmp() -> FFMpegDemuxerOption:
@@ -4411,7 +4411,7 @@ def pmp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def png_pipe(
@@ -4435,7 +4435,7 @@ def png_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4455,7 +4455,7 @@ def pp_bnk() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ppm_pipe(
@@ -4479,7 +4479,7 @@ def ppm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4512,7 +4512,7 @@ def psd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4532,7 +4532,7 @@ def psxstr() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def pulse(
@@ -4562,7 +4562,7 @@ def pulse(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "server": server,
                 "name": name,
@@ -4585,7 +4585,7 @@ def pva() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def pvf() -> FFMpegDemuxerOption:
@@ -4596,7 +4596,7 @@ def pvf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def qcp() -> FFMpegDemuxerOption:
@@ -4607,7 +4607,7 @@ def qcp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def qdraw_pipe(
@@ -4631,7 +4631,7 @@ def qdraw_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4664,7 +4664,7 @@ def qoi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -4684,7 +4684,7 @@ def r3d() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rawvideo(
@@ -4704,7 +4704,7 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "pixel_format": pixel_format,
                 "video_size": video_size,
@@ -4722,7 +4722,7 @@ def realtext() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def redspark() -> FFMpegDemuxerOption:
@@ -4733,7 +4733,7 @@ def redspark() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rka() -> FFMpegDemuxerOption:
@@ -4744,7 +4744,7 @@ def rka() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rl2() -> FFMpegDemuxerOption:
@@ -4755,7 +4755,7 @@ def rl2() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rm() -> FFMpegDemuxerOption:
@@ -4766,7 +4766,7 @@ def rm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def roq() -> FFMpegDemuxerOption:
@@ -4777,7 +4777,7 @@ def roq() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rpl() -> FFMpegDemuxerOption:
@@ -4788,7 +4788,7 @@ def rpl() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rsd() -> FFMpegDemuxerOption:
@@ -4799,7 +4799,7 @@ def rsd() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rso() -> FFMpegDemuxerOption:
@@ -4810,7 +4810,7 @@ def rso() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def rtp(
@@ -4836,7 +4836,7 @@ def rtp(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "rtp_flags": rtp_flags,
                 "listen_timeout": listen_timeout,
@@ -4882,7 +4882,7 @@ def rtsp(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "initial_pause": initial_pause,
                 "rtsp_transport": rtsp_transport,
@@ -4917,7 +4917,7 @@ def s16be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -4944,7 +4944,7 @@ def s16le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -4971,7 +4971,7 @@ def s24be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -4998,7 +4998,7 @@ def s24le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5025,7 +5025,7 @@ def s32be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5052,7 +5052,7 @@ def s32le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5070,7 +5070,7 @@ def s337m() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def s8(
@@ -5090,7 +5090,7 @@ def s8(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5108,7 +5108,7 @@ def sami() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sap() -> FFMpegDemuxerOption:
@@ -5119,7 +5119,7 @@ def sap() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sbc(
@@ -5135,7 +5135,7 @@ def sbc(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -5158,7 +5158,7 @@ def sbg(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "max_file_size": max_file_size,
@@ -5175,7 +5175,7 @@ def scc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def scd() -> FFMpegDemuxerOption:
@@ -5186,7 +5186,7 @@ def scd() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sdns() -> FFMpegDemuxerOption:
@@ -5197,7 +5197,7 @@ def sdns() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sdp(
@@ -5223,7 +5223,7 @@ def sdp(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sdp_flags": sdp_flags,
                 "listen_timeout": listen_timeout,
@@ -5244,7 +5244,7 @@ def sdr2() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sds() -> FFMpegDemuxerOption:
@@ -5255,7 +5255,7 @@ def sds() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sdx() -> FFMpegDemuxerOption:
@@ -5266,7 +5266,7 @@ def sdx() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ser(
@@ -5282,7 +5282,7 @@ def ser(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
             }
@@ -5298,7 +5298,7 @@ def sga() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sgi_pipe(
@@ -5322,7 +5322,7 @@ def sgi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -5347,7 +5347,7 @@ def shn(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -5363,7 +5363,7 @@ def siff() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def simbiosis_imx() -> FFMpegDemuxerOption:
@@ -5374,7 +5374,7 @@ def simbiosis_imx() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sln(
@@ -5394,7 +5394,7 @@ def sln(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5412,7 +5412,7 @@ def smjpeg() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def smk() -> FFMpegDemuxerOption:
@@ -5423,7 +5423,7 @@ def smk() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def smush() -> FFMpegDemuxerOption:
@@ -5434,7 +5434,7 @@ def smush() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sol() -> FFMpegDemuxerOption:
@@ -5445,7 +5445,7 @@ def sol() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sox() -> FFMpegDemuxerOption:
@@ -5456,7 +5456,7 @@ def sox() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def spdif() -> FFMpegDemuxerOption:
@@ -5467,7 +5467,7 @@ def spdif() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def srt() -> FFMpegDemuxerOption:
@@ -5478,7 +5478,7 @@ def srt() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def stl() -> FFMpegDemuxerOption:
@@ -5489,7 +5489,7 @@ def stl() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def subviewer() -> FFMpegDemuxerOption:
@@ -5500,7 +5500,7 @@ def subviewer() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def subviewer1() -> FFMpegDemuxerOption:
@@ -5511,7 +5511,7 @@ def subviewer1() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def sunrast_pipe(
@@ -5535,7 +5535,7 @@ def sunrast_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -5555,7 +5555,7 @@ def sup() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def svag() -> FFMpegDemuxerOption:
@@ -5566,7 +5566,7 @@ def svag() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def svg_pipe(
@@ -5590,7 +5590,7 @@ def svg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -5610,7 +5610,7 @@ def svs() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def swf() -> FFMpegDemuxerOption:
@@ -5621,7 +5621,7 @@ def swf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def tak(
@@ -5637,7 +5637,7 @@ def tak(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -5658,7 +5658,7 @@ def tedcaptions(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "start_time": start_time,
             }
@@ -5674,7 +5674,7 @@ def thp() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def tiertexseq() -> FFMpegDemuxerOption:
@@ -5685,7 +5685,7 @@ def tiertexseq() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def tiff_pipe(
@@ -5709,7 +5709,7 @@ def tiff_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -5729,7 +5729,7 @@ def tmv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def truehd(
@@ -5745,7 +5745,7 @@ def truehd(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -5761,7 +5761,7 @@ def tta() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def tty(
@@ -5781,7 +5781,7 @@ def tty(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "chars_per_frame": chars_per_frame,
                 "video_size": video_size,
@@ -5799,7 +5799,7 @@ def txd() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def ty() -> FFMpegDemuxerOption:
@@ -5810,7 +5810,7 @@ def ty() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def u16be(
@@ -5830,7 +5830,7 @@ def u16be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5857,7 +5857,7 @@ def u16le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5884,7 +5884,7 @@ def u24be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5911,7 +5911,7 @@ def u24le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5938,7 +5938,7 @@ def u32be(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5965,7 +5965,7 @@ def u32le(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -5992,7 +5992,7 @@ def u8(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -6010,7 +6010,7 @@ def usm() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def v210(
@@ -6028,7 +6028,7 @@ def v210(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "video_size": video_size,
                 "framerate": framerate,
@@ -6052,7 +6052,7 @@ def v210x(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "video_size": video_size,
                 "framerate": framerate,
@@ -6069,7 +6069,7 @@ def vag() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vbn_pipe(
@@ -6093,7 +6093,7 @@ def vbn_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -6120,7 +6120,7 @@ def vc1(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -6137,7 +6137,7 @@ def vc1test() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vidc(
@@ -6157,7 +6157,7 @@ def vidc(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sample_rate": sample_rate,
                 "channels": channels,
@@ -6175,7 +6175,7 @@ def vividas() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vivo() -> FFMpegDemuxerOption:
@@ -6186,7 +6186,7 @@ def vivo() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vmd() -> FFMpegDemuxerOption:
@@ -6197,7 +6197,7 @@ def vmd() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vobsub(
@@ -6213,7 +6213,7 @@ def vobsub(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "sub_name": sub_name,
             }
@@ -6229,7 +6229,7 @@ def voc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vpk() -> FFMpegDemuxerOption:
@@ -6240,7 +6240,7 @@ def vpk() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vplayer() -> FFMpegDemuxerOption:
@@ -6251,7 +6251,7 @@ def vplayer() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vqf() -> FFMpegDemuxerOption:
@@ -6262,7 +6262,7 @@ def vqf() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def vvc(
@@ -6280,7 +6280,7 @@ def vvc(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "framerate": framerate,
                 "raw_packet_size": raw_packet_size,
@@ -6302,7 +6302,7 @@ def w64(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "max_size": max_size,
             }
@@ -6318,7 +6318,7 @@ def wady() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def wav(
@@ -6336,7 +6336,7 @@ def wav(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "ignore_length": ignore_length,
                 "max_size": max_size,
@@ -6353,7 +6353,7 @@ def wavarc() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def wc3movie() -> FFMpegDemuxerOption:
@@ -6364,7 +6364,7 @@ def wc3movie() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def webm_dash_manifest(
@@ -6382,7 +6382,7 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "live": live,
                 "bandwidth": bandwidth,
@@ -6412,7 +6412,7 @@ def webp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -6439,7 +6439,7 @@ def webvtt(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "kind": kind,
             }
@@ -6455,7 +6455,7 @@ def wsaud() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def wsd(
@@ -6471,7 +6471,7 @@ def wsd(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "raw_packet_size": raw_packet_size,
             }
@@ -6487,7 +6487,7 @@ def wsvqa() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def wtv() -> FFMpegDemuxerOption:
@@ -6498,7 +6498,7 @@ def wtv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def wv() -> FFMpegDemuxerOption:
@@ -6509,7 +6509,7 @@ def wv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def wve() -> FFMpegDemuxerOption:
@@ -6520,7 +6520,7 @@ def wve() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def x11grab(
@@ -6558,7 +6558,7 @@ def x11grab(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "window_id": window_id,
                 "x": x,
@@ -6585,7 +6585,7 @@ def xa() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def xbin(
@@ -6605,7 +6605,7 @@ def xbin(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "linespeed": linespeed,
                 "video_size": video_size,
@@ -6636,7 +6636,7 @@ def xbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -6656,7 +6656,7 @@ def xmd() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def xmv() -> FFMpegDemuxerOption:
@@ -6667,7 +6667,7 @@ def xmv() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def xpm_pipe(
@@ -6691,7 +6691,7 @@ def xpm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -6711,7 +6711,7 @@ def xvag() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def xwd_pipe(
@@ -6735,7 +6735,7 @@ def xwd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "frame_size": frame_size,
                 "framerate": framerate,
@@ -6755,7 +6755,7 @@ def xwma() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def yop() -> FFMpegDemuxerOption:
@@ -6766,7 +6766,7 @@ def yop() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))
 
 
 def yuv4mpegpipe() -> FFMpegDemuxerOption:
@@ -6777,4 +6777,4 @@ def yuv4mpegpipe() -> FFMpegDemuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({}))
+    return FFMpegDemuxerOption(merge({}))

--- a/src/ffmpeg/formats/muxers.py
+++ b/src/ffmpeg/formats/muxers.py
@@ -66,7 +66,7 @@ def _3g2(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -159,7 +159,7 @@ def _3gp(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -199,7 +199,7 @@ def a64() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def ac3() -> FFMpegMuxerOption:
@@ -210,7 +210,7 @@ def ac3() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def ac4(
@@ -226,7 +226,7 @@ def ac4(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "write_crc": write_crc,
             }
@@ -251,7 +251,7 @@ def adts(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "write_id3v2": write_id3v2,
                 "write_apetag": write_apetag,
@@ -269,7 +269,7 @@ def adx() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def aiff(
@@ -287,7 +287,7 @@ def aiff(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "write_id3v2": write_id3v2,
                 "id3v2_version": id3v2_version,
@@ -304,7 +304,7 @@ def alaw() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def alp(
@@ -320,7 +320,7 @@ def alp(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "type": type,
             }
@@ -336,7 +336,7 @@ def alsa() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def amr() -> FFMpegMuxerOption:
@@ -347,7 +347,7 @@ def amr() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def amv() -> FFMpegMuxerOption:
@@ -358,7 +358,7 @@ def amv() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def apm() -> FFMpegMuxerOption:
@@ -369,7 +369,7 @@ def apm() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def apng(
@@ -387,7 +387,7 @@ def apng(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "plays": plays,
                 "final_delay": final_delay,
@@ -404,7 +404,7 @@ def aptx() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def aptx_hd() -> FFMpegMuxerOption:
@@ -415,7 +415,7 @@ def aptx_hd() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def argo_asf(
@@ -435,7 +435,7 @@ def argo_asf(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "version_major": version_major,
                 "version_minor": version_minor,
@@ -462,7 +462,7 @@ def argo_cvg(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "skip_rate_check": skip_rate_check,
                 "loop": loop,
@@ -485,7 +485,7 @@ def asf(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "packet_size": packet_size,
             }
@@ -506,7 +506,7 @@ def asf_stream(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "packet_size": packet_size,
             }
@@ -527,7 +527,7 @@ def ass(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "ignore_readorder": ignore_readorder,
             }
@@ -550,7 +550,7 @@ def ast(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "loopstart": loopstart,
                 "loopend": loopend,
@@ -567,7 +567,7 @@ def au() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def avi(
@@ -587,7 +587,7 @@ def avi(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "reserve_index_space": reserve_index_space,
                 "write_channel_mask": write_channel_mask,
@@ -612,7 +612,7 @@ def avif(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movie_timescale": movie_timescale,
                 "loop": loop,
@@ -629,7 +629,7 @@ def avm2() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def avs2() -> FFMpegMuxerOption:
@@ -640,7 +640,7 @@ def avs2() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def avs3() -> FFMpegMuxerOption:
@@ -651,7 +651,7 @@ def avs3() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def bit() -> FFMpegMuxerOption:
@@ -662,7 +662,7 @@ def bit() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def caca(
@@ -696,7 +696,7 @@ def caca(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "window_size": window_size,
                 "window_title": window_title,
@@ -720,7 +720,7 @@ def caf() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def cavsvideo() -> FFMpegMuxerOption:
@@ -731,7 +731,7 @@ def cavsvideo() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def chromaprint(
@@ -751,7 +751,7 @@ def chromaprint(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "silence_threshold": silence_threshold,
                 "algorithm": algorithm,
@@ -769,7 +769,7 @@ def codec2() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def codec2raw() -> FFMpegMuxerOption:
@@ -780,7 +780,7 @@ def codec2raw() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def crc() -> FFMpegMuxerOption:
@@ -791,7 +791,7 @@ def crc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dash(
@@ -879,7 +879,7 @@ def dash(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "adaptation_sets": adaptation_sets,
                 "window_size": window_size,
@@ -930,7 +930,7 @@ def data() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def daud() -> FFMpegMuxerOption:
@@ -941,7 +941,7 @@ def daud() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dfpwm() -> FFMpegMuxerOption:
@@ -952,7 +952,7 @@ def dfpwm() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dirac() -> FFMpegMuxerOption:
@@ -963,7 +963,7 @@ def dirac() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dnxhd() -> FFMpegMuxerOption:
@@ -974,7 +974,7 @@ def dnxhd() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dts() -> FFMpegMuxerOption:
@@ -985,7 +985,7 @@ def dts() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dv() -> FFMpegMuxerOption:
@@ -996,7 +996,7 @@ def dv() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def dvd(
@@ -1014,7 +1014,7 @@ def dvd(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "muxrate": muxrate,
                 "preload": preload,
@@ -1031,7 +1031,7 @@ def eac3() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def evc() -> FFMpegMuxerOption:
@@ -1042,7 +1042,7 @@ def evc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def f32be() -> FFMpegMuxerOption:
@@ -1053,7 +1053,7 @@ def f32be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def f32le() -> FFMpegMuxerOption:
@@ -1064,7 +1064,7 @@ def f32le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def f4v(
@@ -1128,7 +1128,7 @@ def f4v(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -1168,7 +1168,7 @@ def f64be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def f64le() -> FFMpegMuxerOption:
@@ -1179,7 +1179,7 @@ def f64le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def fbdev(
@@ -1197,7 +1197,7 @@ def fbdev(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "xoffset": xoffset,
                 "yoffset": yoffset,
@@ -1214,7 +1214,7 @@ def ffmetadata() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def fifo(
@@ -1250,7 +1250,7 @@ def fifo(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "fifo_format": fifo_format,
                 "queue_size": queue_size,
@@ -1285,7 +1285,7 @@ def fifo_test(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "write_header_ret": write_header_ret,
                 "write_trailer_ret": write_trailer_ret,
@@ -1303,7 +1303,7 @@ def film_cpk() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def filmstrip() -> FFMpegMuxerOption:
@@ -1314,7 +1314,7 @@ def filmstrip() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def fits() -> FFMpegMuxerOption:
@@ -1325,7 +1325,7 @@ def fits() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def flac(
@@ -1341,7 +1341,7 @@ def flac(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "write_header": write_header,
             }
@@ -1362,7 +1362,7 @@ def flv(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "flvflags": flvflags,
             }
@@ -1378,7 +1378,7 @@ def framecrc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def framehash(
@@ -1396,7 +1396,7 @@ def framehash(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "hash": hash,
                 "format_version": format_version,
@@ -1420,7 +1420,7 @@ def framemd5(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "hash": hash,
                 "format_version": format_version,
@@ -1437,7 +1437,7 @@ def g722() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def g723_1() -> FFMpegMuxerOption:
@@ -1448,7 +1448,7 @@ def g723_1() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def g726() -> FFMpegMuxerOption:
@@ -1459,7 +1459,7 @@ def g726() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def g726le() -> FFMpegMuxerOption:
@@ -1470,7 +1470,7 @@ def g726le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def gif(
@@ -1488,7 +1488,7 @@ def gif(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "loop": loop,
                 "final_delay": final_delay,
@@ -1505,7 +1505,7 @@ def gsm() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def gxf() -> FFMpegMuxerOption:
@@ -1516,7 +1516,7 @@ def gxf() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def h261() -> FFMpegMuxerOption:
@@ -1527,7 +1527,7 @@ def h261() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def h263() -> FFMpegMuxerOption:
@@ -1538,7 +1538,7 @@ def h263() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def h264() -> FFMpegMuxerOption:
@@ -1549,7 +1549,7 @@ def h264() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def hash(
@@ -1565,7 +1565,7 @@ def hash(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "hash": hash,
             }
@@ -1592,7 +1592,7 @@ def hds(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "window_size": window_size,
                 "extra_window_size": extra_window_size,
@@ -1611,7 +1611,7 @@ def hevc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def hls(
@@ -1697,7 +1697,7 @@ def hls(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "start_number": start_number,
                 "hls_time": hls_time,
@@ -1747,7 +1747,7 @@ def ico() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def ilbc() -> FFMpegMuxerOption:
@@ -1758,7 +1758,7 @@ def ilbc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def image2(
@@ -1784,7 +1784,7 @@ def image2(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "update": update,
                 "start_number": start_number,
@@ -1805,7 +1805,7 @@ def image2pipe() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def ipod(
@@ -1869,7 +1869,7 @@ def ipod(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -1909,7 +1909,7 @@ def ircam() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def ismv(
@@ -1973,7 +1973,7 @@ def ismv(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -2013,7 +2013,7 @@ def ivf() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def jacosub() -> FFMpegMuxerOption:
@@ -2024,7 +2024,7 @@ def jacosub() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def kvag() -> FFMpegMuxerOption:
@@ -2035,7 +2035,7 @@ def kvag() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def latm(
@@ -2051,7 +2051,7 @@ def latm(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "smc-interval": smc_interval,
             }
@@ -2067,7 +2067,7 @@ def lrc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def m4v() -> FFMpegMuxerOption:
@@ -2078,7 +2078,7 @@ def m4v() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def matroska(
@@ -2114,7 +2114,7 @@ def matroska(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "reserve_index_space": reserve_index_space,
                 "cues_to_front": cues_to_front,
@@ -2145,7 +2145,7 @@ def md5(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "hash": hash,
             }
@@ -2161,7 +2161,7 @@ def microdvd() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mjpeg() -> FFMpegMuxerOption:
@@ -2172,7 +2172,7 @@ def mjpeg() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mkvtimestamp_v2() -> FFMpegMuxerOption:
@@ -2183,7 +2183,7 @@ def mkvtimestamp_v2() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mlp() -> FFMpegMuxerOption:
@@ -2194,7 +2194,7 @@ def mlp() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mmf() -> FFMpegMuxerOption:
@@ -2205,7 +2205,7 @@ def mmf() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mov(
@@ -2269,7 +2269,7 @@ def mov(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -2309,7 +2309,7 @@ def mp2() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mp3(
@@ -2329,7 +2329,7 @@ def mp3(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "id3v2_version": id3v2_version,
                 "write_id3v1": write_id3v1,
@@ -2400,7 +2400,7 @@ def mp4(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -2447,7 +2447,7 @@ def mpeg(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "muxrate": muxrate,
                 "preload": preload,
@@ -2464,7 +2464,7 @@ def mpeg1video() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mpeg2video() -> FFMpegMuxerOption:
@@ -2475,7 +2475,7 @@ def mpeg2video() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mpegts(
@@ -2534,7 +2534,7 @@ def mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "mpegts_transport_stream_id": mpegts_transport_stream_id,
                 "mpegts_original_network_id": mpegts_original_network_id,
@@ -2571,7 +2571,7 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "boundary_tag": boundary_tag,
             }
@@ -2587,7 +2587,7 @@ def mulaw() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def mxf(
@@ -2615,7 +2615,7 @@ def mxf(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "signal_standard": signal_standard,
                 "store_user_comments": store_user_comments,
@@ -2651,7 +2651,7 @@ def mxf_d10(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "d10_channelcount": d10_channelcount,
                 "signal_standard": signal_standard,
@@ -2688,7 +2688,7 @@ def mxf_opatom(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "mxf_audio_edit_rate": mxf_audio_edit_rate,
                 "signal_standard": signal_standard,
@@ -2706,7 +2706,7 @@ def null() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def nut(
@@ -2724,7 +2724,7 @@ def nut(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "syncpoints": syncpoints,
                 "write_index": write_index,
@@ -2741,7 +2741,7 @@ def obu() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def oga(
@@ -2763,7 +2763,7 @@ def oga(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "serial_offset": serial_offset,
                 "oggpagesize": oggpagesize,
@@ -2793,7 +2793,7 @@ def ogg(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "serial_offset": serial_offset,
                 "oggpagesize": oggpagesize,
@@ -2823,7 +2823,7 @@ def ogv(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "serial_offset": serial_offset,
                 "oggpagesize": oggpagesize,
@@ -2842,7 +2842,7 @@ def oma() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def opengl(
@@ -2864,7 +2864,7 @@ def opengl(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "background": background,
                 "no_window": no_window,
@@ -2894,7 +2894,7 @@ def opus(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "serial_offset": serial_offset,
                 "oggpagesize": oggpagesize,
@@ -2913,7 +2913,7 @@ def oss() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def psp(
@@ -2977,7 +2977,7 @@ def psp(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "movflags": movflags,
                 "moov_size": moov_size,
@@ -3036,7 +3036,7 @@ def pulse(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "server": server,
                 "name": name,
@@ -3059,7 +3059,7 @@ def rawvideo() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def rm() -> FFMpegMuxerOption:
@@ -3070,7 +3070,7 @@ def rm() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def roq() -> FFMpegMuxerOption:
@@ -3081,7 +3081,7 @@ def roq() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def rso() -> FFMpegMuxerOption:
@@ -3092,7 +3092,7 @@ def rso() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def rtp(
@@ -3116,7 +3116,7 @@ def rtp(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "rtpflags": rtpflags,
                 "payload_type": payload_type,
@@ -3143,7 +3143,7 @@ def rtp_mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "mpegts_muxer_options": mpegts_muxer_options,
                 "rtp_muxer_options": rtp_muxer_options,
@@ -3175,7 +3175,7 @@ def rtsp(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "rtpflags": rtpflags,
                 "rtsp_transport": rtsp_transport,
@@ -3196,7 +3196,7 @@ def s16be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def s16le() -> FFMpegMuxerOption:
@@ -3207,7 +3207,7 @@ def s16le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def s24be() -> FFMpegMuxerOption:
@@ -3218,7 +3218,7 @@ def s24be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def s24le() -> FFMpegMuxerOption:
@@ -3229,7 +3229,7 @@ def s24le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def s32be() -> FFMpegMuxerOption:
@@ -3240,7 +3240,7 @@ def s32be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def s32le() -> FFMpegMuxerOption:
@@ -3251,7 +3251,7 @@ def s32le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def s8() -> FFMpegMuxerOption:
@@ -3262,7 +3262,7 @@ def s8() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def sap() -> FFMpegMuxerOption:
@@ -3273,7 +3273,7 @@ def sap() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def sbc() -> FFMpegMuxerOption:
@@ -3284,7 +3284,7 @@ def sbc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def scc() -> FFMpegMuxerOption:
@@ -3295,7 +3295,7 @@ def scc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def segment(
@@ -3367,7 +3367,7 @@ def segment(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "reference_stream": reference_stream,
                 "segment_format": segment_format,
@@ -3410,7 +3410,7 @@ def smjpeg() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def smoothstreaming(
@@ -3434,7 +3434,7 @@ def smoothstreaming(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "window_size": window_size,
                 "extra_window_size": extra_window_size,
@@ -3454,7 +3454,7 @@ def sox() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def spdif(
@@ -3474,7 +3474,7 @@ def spdif(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "spdif_flags": spdif_flags,
                 "dtshd_rate": dtshd_rate,
@@ -3503,7 +3503,7 @@ def spx(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "serial_offset": serial_offset,
                 "oggpagesize": oggpagesize,
@@ -3522,7 +3522,7 @@ def srt() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def streamhash(
@@ -3538,7 +3538,7 @@ def streamhash(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "hash": hash,
             }
@@ -3554,7 +3554,7 @@ def sup() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def svcd(
@@ -3572,7 +3572,7 @@ def svcd(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "muxrate": muxrate,
                 "preload": preload,
@@ -3589,7 +3589,7 @@ def swf() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def tee(
@@ -3607,7 +3607,7 @@ def tee(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "use_fifo": use_fifo,
                 "fifo_options": fifo_options,
@@ -3624,7 +3624,7 @@ def truehd() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def tta() -> FFMpegMuxerOption:
@@ -3635,7 +3635,7 @@ def tta() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def ttml() -> FFMpegMuxerOption:
@@ -3646,7 +3646,7 @@ def ttml() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u16be() -> FFMpegMuxerOption:
@@ -3657,7 +3657,7 @@ def u16be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u16le() -> FFMpegMuxerOption:
@@ -3668,7 +3668,7 @@ def u16le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u24be() -> FFMpegMuxerOption:
@@ -3679,7 +3679,7 @@ def u24be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u24le() -> FFMpegMuxerOption:
@@ -3690,7 +3690,7 @@ def u24le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u32be() -> FFMpegMuxerOption:
@@ -3701,7 +3701,7 @@ def u32be() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u32le() -> FFMpegMuxerOption:
@@ -3712,7 +3712,7 @@ def u32le() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def u8() -> FFMpegMuxerOption:
@@ -3723,7 +3723,7 @@ def u8() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def uncodedframecrc() -> FFMpegMuxerOption:
@@ -3734,7 +3734,7 @@ def uncodedframecrc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def vc1() -> FFMpegMuxerOption:
@@ -3745,7 +3745,7 @@ def vc1() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def vc1test() -> FFMpegMuxerOption:
@@ -3756,7 +3756,7 @@ def vc1test() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def vcd(
@@ -3774,7 +3774,7 @@ def vcd(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "muxrate": muxrate,
                 "preload": preload,
@@ -3791,7 +3791,7 @@ def vidc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def vob(
@@ -3809,7 +3809,7 @@ def vob(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "muxrate": muxrate,
                 "preload": preload,
@@ -3826,7 +3826,7 @@ def voc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def vvc() -> FFMpegMuxerOption:
@@ -3837,7 +3837,7 @@ def vvc() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def w64() -> FFMpegMuxerOption:
@@ -3848,7 +3848,7 @@ def w64() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def wav(
@@ -3874,7 +3874,7 @@ def wav(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "write_bext": write_bext,
                 "write_peak": write_peak,
@@ -3920,7 +3920,7 @@ def webm(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "reserve_index_space": reserve_index_space,
                 "cues_to_front": cues_to_front,
@@ -3957,7 +3957,7 @@ def webm_chunk(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "chunk_start_index": chunk_start_index,
                 "header": header,
@@ -3993,7 +3993,7 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "adaptation_sets": adaptation_sets,
                 "live": live,
@@ -4020,7 +4020,7 @@ def webp(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "loop": loop,
             }
@@ -4036,7 +4036,7 @@ def webvtt() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def wsaud() -> FFMpegMuxerOption:
@@ -4047,7 +4047,7 @@ def wsaud() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def wtv() -> FFMpegMuxerOption:
@@ -4058,7 +4058,7 @@ def wtv() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def wv() -> FFMpegMuxerOption:
@@ -4069,7 +4069,7 @@ def wv() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))
 
 
 def xv(
@@ -4095,7 +4095,7 @@ def xv(
         the set codec options
     """
     return FFMpegMuxerOption(
-        kwargs=merge(
+        merge(
             {
                 "display_name": display_name,
                 "window_id": window_id,
@@ -4116,4 +4116,4 @@ def yuv4mpegpipe() -> FFMpegMuxerOption:
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({}))
+    return FFMpegMuxerOption(merge({}))

--- a/src/ffmpeg/formats/schema.py
+++ b/src/ffmpeg/formats/schema.py
@@ -1,11 +1,7 @@
-from dataclasses import dataclass
-
 from ..schema import FFMpegOptionGroup
 
 
-@dataclass(frozen=True, kw_only=True)
 class FFMpegMuxerOption(FFMpegOptionGroup): ...
 
 
-@dataclass(frozen=True, kw_only=True)
 class FFMpegDemuxerOption(FFMpegOptionGroup): ...

--- a/src/ffmpeg/schema.py
+++ b/src/ffmpeg/schema.py
@@ -7,11 +7,9 @@ These components form the foundation of the type annotation system that
 enables static type checking in the FFmpeg filter graph.
 """
 
-from dataclasses import dataclass
+from typing import Any
 
 from .common.schema import StreamType
-from .common.serialize import Serializable
-from .utils.frozendict import FrozenDict
 
 
 class Default(str):
@@ -52,15 +50,14 @@ class Auto(Default):
     """
 
 
-@dataclass(frozen=True, kw_only=True)
-class FFMpegOptionGroup(Serializable):
+class FFMpegOptionGroup(dict[str, Any]):
     """
     Represents a group of FFmpeg options.
 
     This class is used to group options together, such as a codec or format.
     """
 
-    kwargs: FrozenDict[str, str | int | float | bool] = FrozenDict({})
+    ...
 
 
 __all__ = [

--- a/src/scripts/code_gen/templates/codecs/decoders.py.jinja
+++ b/src/scripts/code_gen/templates/codecs/decoders.py.jinja
@@ -21,7 +21,7 @@ def {{codec.name | option_name_safe }}(
     Returns:
         the set codec options
     """
-    return FFMpegDecoderOption(kwargs=merge({
+    return FFMpegDecoderOption(merge({
         {% for option in codec.filtered_options() %}
         "{{ option.name}}": {{ option.name | option_name_safe }},
         {% endfor %}

--- a/src/scripts/code_gen/templates/codecs/encoders.py.jinja
+++ b/src/scripts/code_gen/templates/codecs/encoders.py.jinja
@@ -21,7 +21,7 @@ def {{codec.name | option_name_safe }}(
     Returns:
         the set codec options
     """
-    return FFMpegEncoderOption(kwargs=merge({
+    return FFMpegEncoderOption(merge({
         {% for option in codec.filtered_options() %}
         "{{ option.name}}": {{ option.name | option_name_safe }},
         {% endfor %}

--- a/src/scripts/code_gen/templates/dag/io/_input.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/_input.py.jinja
@@ -55,5 +55,5 @@ def input(
                 "{{ option.name}}": {{ option.name | option_name_safe }},
                 {% endif %}
                 {% endfor %}
-        }, decoder_options.kwargs if decoder_options else {}, demuxer_options.kwargs if demuxer_options else {}, extra_options )
+        }, decoder_options, demuxer_options, extra_options )
     ).stream()

--- a/src/scripts/code_gen/templates/dag/io/_output.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/_output.py.jinja
@@ -51,5 +51,5 @@ def output(
                 "{{ option.name}}": {{ option.name | option_name_safe }},
                 {% endif %}
                 {% endfor %}
-        }, encoder_options.kwargs if encoder_options else {}, muxer_options.kwargs if muxer_options else {}, extra_options )
+        }, encoder_options, muxer_options, extra_options )
     ).stream()

--- a/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
@@ -58,4 +58,4 @@ class OutputArgs(ABC):
                 "{{ option.name}}": {{ option.name | option_name_safe }},
                 {% endif %}
             {% endfor %}
-        }, encoder_options.kwargs if encoder_options else {}, muxer_options.kwargs if muxer_options else {}, extra_options)).stream()
+        }, encoder_options, muxer_options, extra_options)).stream()

--- a/src/scripts/code_gen/templates/formats/demuxers.py.jinja
+++ b/src/scripts/code_gen/templates/formats/demuxers.py.jinja
@@ -21,7 +21,7 @@ def {{codec.name | option_name_safe }}(
     Returns:
         the set codec options
     """
-    return FFMpegDemuxerOption(kwargs=merge({
+    return FFMpegDemuxerOption(merge({
         {% for option in codec.options %}
         "{{ option.name}}": {{ option.name | option_name_safe }},
         {% endfor %}

--- a/src/scripts/code_gen/templates/formats/muxers.py.jinja
+++ b/src/scripts/code_gen/templates/formats/muxers.py.jinja
@@ -21,7 +21,7 @@ def {{codec.name | option_name_safe }}(
     Returns:
         the set codec options
     """
-    return FFMpegMuxerOption(kwargs=merge({
+    return FFMpegMuxerOption(merge({
         {% for option in codec.options %}
         "{{ option.name}}": {{ option.name | option_name_safe }},
         {% endfor %}

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_input.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_input.py].raw
@@ -43,5 +43,5 @@ def input(
         filename=str(filename),
         kwargs=merge({
             
-        }, decoder_options.kwargs if decoder_options else {}, demuxer_options.kwargs if demuxer_options else {}, extra_options )
+        }, decoder_options, demuxer_options, extra_options )
     ).stream()

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_output.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_output.py].raw
@@ -39,5 +39,5 @@ def output(
         filename=str(filename),
         kwargs=merge({
             
-        }, encoder_options.kwargs if encoder_options else {}, muxer_options.kwargs if muxer_options else {}, extra_options )
+        }, encoder_options, muxer_options, extra_options )
     ).stream()

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[output_args.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[output_args.py].raw
@@ -46,4 +46,4 @@ class OutputArgs(ABC):
 
         return self._output_node(*streams, filename=filename, **merge({
             
-        }, encoder_options.kwargs if encoder_options else {}, muxer_options.kwargs if muxer_options else {}, extra_options)).stream()
+        }, encoder_options, muxer_options, extra_options)).stream()


### PR DESCRIPTION
This pull request refactors the handling of codec and muxer options in the `ffmpeg` module to simplify the code and improve consistency. The most significant changes include removing the `kwargs` parameter from `FFMpegMuxerOption` and directly passing merged options, as well as updating related functions to reflect this change.

### Refactoring of codec and muxer options:

* [`src/ffmpeg/codecs/schema.py`](diffhunk://#diff-bd3cf27a92864b75094482170c8ccad31f20306915e273d43e7d59ad752a9252L1-L10): Removed the `@dataclass` decorator from `FFMpegEncoderOption` and `FFMpegDecoderOption`, simplifying their definitions.
* [`src/ffmpeg/dag/io/_input.py`](diffhunk://#diff-a89ab89f0249537fc264610f8dbfeb6a16b92866ccb15636f1e305b68062d39eL208-R209): Updated the `input` function to pass `decoder_options` and `demuxer_options` directly instead of accessing their `kwargs` attributes.
* [`src/ffmpeg/dag/io/_output.py`](diffhunk://#diff-e08b8eb703de06409ac7d2305f43158549b6bb89320bf544f2eea10b74f8d3c0L332-R333): Updated the `output` function to pass `encoder_options` and `muxer_options` directly instead of accessing their `kwargs` attributes. [[1]](diffhunk://#diff-e08b8eb703de06409ac7d2305f43158549b6bb89320bf544f2eea10b74f8d3c0L332-R333) [[2]](diffhunk://#diff-aec5163c7cc18a87545571da330b31935c264f9c454d4c8cc67d2bcb54ce746fL344-R345)

### Simplification of `FFMpegMuxerOption`:

* [`src/ffmpeg/formats/muxers.py`](diffhunk://#diff-1bd140ede63bc039784741f3f7a4b93019448d9ca7dd3647c0ec5ef91278ce43L69-R69): Removed the `kwargs` parameter from `FFMpegMuxerOption` in multiple functions, directly passing merged options instead. This change affects functions such as `_3g2`, `_3gp`, `a64`, `ac3`, `ac4`, and many others. [[1]](diffhunk://#diff-1bd140ede63bc039784741f3f7a4b93019448d9ca7dd3647c0ec5ef91278ce43L69-R69) [[2]](diffhunk://#diff-1bd140ede63bc039784741f3f7a4b93019448d9ca7dd3647c0ec5ef91278ce43L162-R162) [[3]](diffhunk://#diff-1bd140ede63bc039784741f3f7a4b93019448d9ca7dd3647c0ec5ef91278ce43L202-R202) [[4]](diffhunk://#diff-1bd140ede63bc039784741f3f7a4b93019448d9ca7dd3647c0ec5ef91278ce43L213-R213) [[5]](diffhunk://#diff-1bd140ede63bc039784741f3f7a4b93019448d9ca7dd3647c0ec5ef91278ce43L229-R229) and more)