### PR TITLE
refactor compile cli test case

### DIFF
--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr
@@ -9,48 +9,24 @@
 # name: test_parse_ffmpeg_commands[complex_command][build-ffmpeg-commands]
   'ffmpeg -nostdin -i input_video.mkv -map 0 -vf \'scale=-1:-1:flags=lanczos,pad=1920:1080:-1:-1,subtitles=\'"\'"\'subtitles.srt\'"\'"\':stream_index=0:force_style=\'"\'"\'Fontname=Gotham Rounded Medium,Fontsize=17,Alignment=2,PrimaryColour=&Hffffff&,MarginV=25\'"\'"\'\' -map 0:a:0 -map 0:v:0 -sn -c:a aac -b:a 192k -ac 2 -c:v libx264 1.8 -map 0 -pix_fmt yuv420p -map_metadata -map_chapters output_video.mp4'
 # ---
-# name: test_parse_ffmpeg_commands[complex_command][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({'vf': True}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None, optional=False),), filename="scale=-1:-1:flags=lanczos,pad=1920:1080:-1:-1,subtitles='subtitles.srt':stream_index=0:force_style='Fontname=Gotham Rounded Medium,Fontsize=17,Alignment=2,PrimaryColour=&Hffffff&,MarginV=25'"), index=None, optional=False), OutputStream(node=OutputNode(kwargs=FrozenDict({'sn': True, 'c:a': 'aac', 'b:a': '192k', 'ac': '2', 'c:v': 'libx264'}), inputs=(AudioStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=0, optional=False), VideoStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=0, optional=False)), filename='1.8'), index=None, optional=False), OutputStream(node=OutputNode(kwargs=FrozenDict({'pix_fmt': 'yuv420p', 'map_metadata': True, 'map_chapters': True}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None, optional=False),), filename='output_video.mp4'), index=None, optional=False))), index=None, optional=False)
-# ---
 # name: test_parse_ffmpeg_commands[escaping][build-ffmpeg-commands]
   'ffmpeg -i input.mov -filter_complex \'[0:v]drawtext=fontfile=resources/fonts/arial.ttf:text=\\\\\\\'"\'"\'\\\\=\\\\\\\\\\;\\\\\\\\\\\\:\\\\\\\'"\'"\':fontcolor=white:fontsize=30:x=(W-tw)/2:y=text_h:borderw=2:timecode=00\\\\\\\\\\\\:00\\\\\\\\\\\\:00\\\\\\\\\\\\:00:r=25/1[s0]\' -map \'[s0]\' output.mp4'
-# ---
-# name: test_parse_ffmpeg_commands[escaping][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(VideoStream(node=FilterNode(kwargs=FrozenDict({'fontfile': 'resources/fonts/arial.ttf', 'text': "'=\\;\\:'", 'fontcolor': 'white', 'fontsize': '30', 'x': '(W-tw)/2', 'y': 'text_h', 'borderw': '2', 'timecode': '00\\:00\\:00\\:00', 'r': '25/1'}), inputs=(VideoStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input.mov'), index=None, optional=False),), name='drawtext', input_typings=(<StreamType.video: 'video'>,), output_typings=(<StreamType.video: 'video'>,)), index=0, optional=False),), filename='output.mp4'), index=None, optional=False),)), index=None, optional=False)
 # ---
 # name: test_parse_ffmpeg_commands[ffmpeg_exe][build-ffmpeg-commands]
   'ffmpeg -i input_video.mkv output_video.mp4'
 # ---
-# name: test_parse_ffmpeg_commands[ffmpeg_exe][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None, optional=False),), filename='output_video.mp4'), index=None, optional=False),)), index=None, optional=False)
-# ---
 # name: test_parse_ffmpeg_commands[global_binary_option][build-ffmpeg-commands]
   'ffmpeg -y -nostdin -i input_video.mkv output_video.mp4'
-# ---
-# name: test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None, optional=False),), filename='output_video.mp4'), index=None, optional=False),)), index=None, optional=False)
 # ---
 # name: test_parse_ffmpeg_commands[ignore_not_exist_option][build-ffmpeg-commands]
   'ffmpeg -y -nostdin -b:v 1000k -b:a 128k output_video.mp4'
 # ---
-# name: test_parse_ffmpeg_commands[ignore_not_exist_option][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({'b:v': '1000k', 'b:a': '128k'}), inputs=(), filename='output_video.mp4'), index=None, optional=False),)), index=None, optional=False)
-# ---
 # name: test_parse_ffmpeg_commands[output_option_with_boolean_option][build-ffmpeg-commands]
   'ffmpeg -y -nostdin -i input_video.mkv -shortest -b:v 1000k -b:a 128k output_video.mp4'
-# ---
-# name: test_parse_ffmpeg_commands[output_option_with_boolean_option][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({'shortest': True, 'b:v': '1000k', 'b:a': '128k'}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None, optional=False),), filename='output_video.mp4'), index=None, optional=False),)), index=None, optional=False)
 # ---
 # name: test_parse_ffmpeg_commands[output_option_with_stream_selector][build-ffmpeg-commands]
   'ffmpeg -y -nostdin -i input_video.mkv -b:v 1000k output_video.mp4'
 # ---
-# name: test_parse_ffmpeg_commands[output_option_with_stream_selector][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({'y': True, 'stdin': False}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({'b:v': '1000k'}), inputs=(AVStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input_video.mkv'), index=None, optional=False),), filename='output_video.mp4'), index=None, optional=False),)), index=None, optional=False)
-# ---
 # name: test_parse_ffmpeg_commands[stream_selector_with_subtitle][build-ffmpeg-commands]
   'ffmpeg -i input.mov -map 0:s output.mp4'
-# ---
-# name: test_parse_ffmpeg_commands[stream_selector_with_subtitle][parse-ffmpeg-commands]
-  GlobalStream(node=GlobalNode(kwargs=FrozenDict({}), inputs=(OutputStream(node=OutputNode(kwargs=FrozenDict({}), inputs=(SubtitleStream(node=InputNode(kwargs=FrozenDict({}), inputs=(), filename='input.mov'), index=None, optional=False),), filename='output.mp4'), index=None, optional=False),)), index=None, optional=False)
 # ---

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[complex_command][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[complex_command][parse-ffmpeg-commands].json
@@ -1,0 +1,75 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "scale=-1:-1:flags=lanczos,pad=1920:1080:-1:-1,subtitles='subtitles.srt':stream_index=0:force_style='Fontname=Gotham Rounded Medium,Fontsize=17,Alignment=2,PrimaryColour=&Hffffff&,MarginV=25'",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({'vf': True})"
+        },
+        "optional": false
+      },
+      {
+        "index": null,
+        "node": {
+          "filename": "1.8",
+          "inputs": [
+            {
+              "index": 0,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            },
+            {
+              "index": 0,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({'sn': True, 'c:a': 'aac', 'b:a': '192k', 'ac': '2', 'c:v': 'libx264'})"
+        },
+        "optional": false
+      },
+      {
+        "index": null,
+        "node": {
+          "filename": "output_video.mp4",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({'pix_fmt': 'yuv420p', 'map_metadata': True, 'map_chapters': True})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({'stdin': False})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[escaping][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[escaping][parse-ffmpeg-commands].json
@@ -1,0 +1,44 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output.mp4",
+          "inputs": [
+            {
+              "index": 0,
+              "node": {
+                "input_typings": [
+                  "video"
+                ],
+                "inputs": [
+                  {
+                    "index": null,
+                    "node": {
+                      "filename": "input.mov",
+                      "inputs": [],
+                      "kwargs": "FrozenDict({})"
+                    },
+                    "optional": false
+                  }
+                ],
+                "kwargs": "FrozenDict({'fontfile': 'resources/fonts/arial.ttf', 'text': \"'=\\\\;\\\\:'\", 'fontcolor': 'white', 'fontsize': '30', 'x': '(W-tw)/2', 'y': 'text_h', 'borderw': '2', 'timecode': '00\\\\:00\\\\:00\\\\:00', 'r': '25/1'})",
+                "name": "drawtext",
+                "output_typings": [
+                  "video"
+                ]
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[ffmpeg_exe][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[ffmpeg_exe][parse-ffmpeg-commands].json
@@ -1,0 +1,28 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output_video.mp4",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands].json
@@ -1,0 +1,28 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output_video.mp4",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({'y': True, 'stdin': False})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[ignore_not_exist_option][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[ignore_not_exist_option][parse-ffmpeg-commands].json
@@ -1,0 +1,18 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output_video.mp4",
+          "inputs": [],
+          "kwargs": "FrozenDict({'b:v': '1000k', 'b:a': '128k'})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({'y': True, 'stdin': False})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[output_option_with_boolean_option][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[output_option_with_boolean_option][parse-ffmpeg-commands].json
@@ -1,0 +1,28 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output_video.mp4",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({'shortest': True, 'b:v': '1000k', 'b:a': '128k'})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({'y': True, 'stdin': False})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[output_option_with_stream_selector][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[output_option_with_stream_selector][parse-ffmpeg-commands].json
@@ -1,0 +1,28 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output_video.mp4",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input_video.mkv",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({'b:v': '1000k'})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({'y': True, 'stdin': False})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[stream_selector_with_subtitle][parse-ffmpeg-commands].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[stream_selector_with_subtitle][parse-ffmpeg-commands].json
@@ -1,0 +1,28 @@
+{
+  "index": null,
+  "node": {
+    "inputs": [
+      {
+        "index": null,
+        "node": {
+          "filename": "output.mp4",
+          "inputs": [
+            {
+              "index": null,
+              "node": {
+                "filename": "input.mov",
+                "inputs": [],
+                "kwargs": "FrozenDict({})"
+              },
+              "optional": false
+            }
+          ],
+          "kwargs": "FrozenDict({})"
+        },
+        "optional": false
+      }
+    ],
+    "kwargs": "FrozenDict({})"
+  },
+  "optional": false
+}

--- a/src/ffmpeg/compile/tests/test_compile_cli.py
+++ b/src/ffmpeg/compile/tests/test_compile_cli.py
@@ -1,3 +1,5 @@
+from dataclasses import asdict
+
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
@@ -76,5 +78,7 @@ def test_get_args_custom_filter(snapshot: SnapshotAssertion) -> None:
 )
 def test_parse_ffmpeg_commands(snapshot: SnapshotAssertion, command: str) -> None:
     parsed = parse(command)
-    assert snapshot(name="parse-ffmpeg-commands") == parsed
+    assert snapshot(
+        name="parse-ffmpeg-commands", extension_class=JSONSnapshotExtension
+    ) == asdict(parsed)
     assert snapshot(name="build-ffmpeg-commands") == compile(parsed)


### PR DESCRIPTION
This pull request updates the snapshot testing framework for FFmpeg command parsing and compilation. It replaces text-based snapshots with JSON-based snapshots for better structure and readability, and modifies the test suite to accommodate this change. Additionally, it introduces a minor refactor to the `test_compile_cli.py` file.

### Snapshot Updates:
* [`src/ffmpeg/compile/tests/__snapshots__/test_compile_cli.ambr`](diffhunk://#diff-265a46bda407bf72dbb55e79acd2df83a62beae66bc413a36fdbe4323e8256bbL12-L56): Removed text-based snapshots for `parse-ffmpeg-commands` tests, leaving only `build-ffmpeg-commands` snapshots.
* JSON snapshots added for `parse-ffmpeg-commands` tests:
  - Complex command parsing (`test_parse_ffmpeg_commands[complex_command][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[complex_command][parse-ffmpeg-commands].jsonR1-R75](diffhunk://#diff-307826ad03744c70287736d0dc7dd83d6e8926a325b4bf7e2a8f73f76549eea1R1-R75))
  - Escaping special characters (`test_parse_ffmpeg_commands[escaping][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[escaping][parse-ffmpeg-commands].jsonR1-R44](diffhunk://#diff-ee880ab49538836da26733bbd4ca201cd7cc8106fa951f38c054315d437878a9R1-R44))
  - Basic FFmpeg execution (`test_parse_ffmpeg_commands[ffmpeg_exe][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[ffmpeg_exe][parse-ffmpeg-commands].jsonR1-R28](diffhunk://#diff-5abb4a1e65f98e24cda1f2990edbc11cea82425caa9c5b19ffb4d8e3c3dbe406R1-R28))
  - Global binary options (`test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[global_binary_option][parse-ffmpeg-commands].jsonR1-R28](diffhunk://#diff-e3c0766a8f650fbf20fa2587bd94cbbf42f14c79f61afdd1b163d62f8f57b225R1-R28))
  - Ignoring non-existent options (`test_parse_ffmpeg_commands[ignore_not_exist_option][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[ignore_not_exist_option][parse-ffmpeg-commands].jsonR1-R18](diffhunk://#diff-40c92591ce889b150f39653d4f1e0887f07675c57a7d20ef5a13239b7941c397R1-R18))
  - Output options with boolean flags (`test_parse_ffmpeg_commands[output_option_with_boolean_option][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[output_option_with_boolean_option][parse-ffmpeg-commands].jsonR1-R28](diffhunk://#diff-bd0f05a72e49ef3e26f8e7c1a98e776a55cb56ddca8922b7c7cd9da3e2fa650bR1-R28))
  - Output options with stream selectors (`test_parse_ffmpeg_commands[output_option_with_stream_selector][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[output_option_with_stream_selector][parse-ffmpeg-commands].jsonR1-R28](diffhunk://#diff-de6a3d361ebf5f57167a9292963db6e8de59dbf2993e53979e126ebca0b410d2R1-R28))
  - Stream selector with subtitles (`test_parse_ffmpeg_commands[stream_selector_with_subtitle][parse-ffmpeg-commands].json`) ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_ffmpeg_commands[stream_selector_with_subtitle][parse-ffmpeg-commands].jsonR1-R28](diffhunk://#diff-1fb5da382ab5d3489b3527afea7f8fff97fda3fb5f9a984ddecb7b951573d364R1-R28))

### Test Suite Modifications:
* [`src/ffmpeg/compile/tests/test_compile_cli.py`](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R1-R2): Added `dataclasses.asdict` import and updated `test_parse_ffmpeg_commands` to use JSON snapshots via `JSONSnapshotExtension`. The parsed command object is converted to a dictionary before assertion for compatibility with JSON snapshots. [[1]](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807R1-R2) [[2]](diffhunk://#diff-f41044319fa755947196da1a92e14e54936c96872f1a682cc14dfeac80c8b807L79-R83)