### PR TITLE
refactor code-gen scripts import method

### DIFF
--- a/src/scripts/manual/__init__.py
+++ b/src/scripts/manual/__init__.py
@@ -14,3 +14,7 @@ These manual definitions supplement the automatically extracted information
 to handle edge cases and special filters that require custom type annotations
 beyond what can be parsed from standard sources.
 """
+
+from . import cli, schema
+
+__all__ = ["cli", "schema"]

--- a/src/scripts/parse_c/__init__.py
+++ b/src/scripts/parse_c/__init__.py
@@ -13,3 +13,7 @@ These modules help create the foundation for typed FFmpeg wrappers by
 extracting accurate information about FFmpeg's functionality directly from
 its source code.
 """
+
+from . import cli
+
+__all__ = ["cli"]

--- a/src/scripts/parse_docs/__init__.py
+++ b/src/scripts/parse_docs/__init__.py
@@ -13,3 +13,7 @@ These modules help provide context and reference information for FFmpeg filters
 that may not be available through command-line help or source code alone,
 enriching the generated type annotations with more detailed documentation.
 """
+
+from . import cli, schema
+
+__all__ = ["cli", "schema"]

--- a/src/scripts/parse_help/__init__.py
+++ b/src/scripts/parse_help/__init__.py
@@ -13,3 +13,7 @@ These modules provide the most detailed and accurate information about FFmpeg fi
 by directly querying the FFmpeg binary, ensuring the generated type annotations
 match the exact behavior of the installed FFmpeg version.
 """
+
+from . import cli, schema
+
+__all__ = ["cli", "schema"]


### PR DESCRIPTION
This pull request refactors the import structure and updates function calls in `src/scripts/code_gen/cli.py` to use module-level imports for better organization and maintainability. Additionally, it modifies the `__init__.py` files in several modules to expose submodules via `__all__`.

### Refactoring imports and function calls:

* Consolidated imports in `src/scripts/code_gen/cli.py` to use module-level imports (`manual`, `parse_c`, `parse_docs`, `parse_help`) instead of importing individual functions directly. This improves readability and reduces redundancy.
* Updated function calls in `src/scripts/code_gen/cli.py` to reference the appropriate submodules, such as `parse_docs.cli.extract_docs` and `manual.cli.load_config`. This ensures consistency with the new import structure. [[1]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L52-R48) [[2]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L76-R72) [[3]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L98-R94) [[4]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L144-R140) [[5]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L192-R188) [[6]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L229-R225) [[7]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L293-R289)

### Enhancements to module initialization:

* Added submodules (`cli`, `schema`) to the `__all__` list in the `__init__.py` files of `manual`, `parse_c`, `parse_docs`, and `parse_help` modules, making them explicitly available for import. [[1]](diffhunk://#diff-0a633fcc714ea527c1ee07b2f1b979fb68bb14ad830bed516bfdde9ab7e41919R17-R20) [[2]](diffhunk://#diff-db4855528b428cb5f8a3a194db80be75f96651e5293de0bf4f5d655658c9651bR16-R19) [[3]](diffhunk://#diff-6f7ef8602d2a88a8110c673d6bebda358686349e81dfe9a222f7a6b490363c2bR16-R19) [[4]](diffhunk://#diff-5d167115325bfaa9807cca551fb52d2845cc92ce17168a021dd2ccb291b6cc0bR16-R19)