### PR TITLE
upgrade pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v5.0.0
     hooks:
       # - id: check-added-large-files
       - id: check-case-conflict


### PR DESCRIPTION
This pull request updates the `.pre-commit-config.yaml` file to use a newer version of the `pre-commit-hooks` repository.

Version update:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3): Upgraded the `pre-commit-hooks` repository version from `v4.0.1` to `v5.0.0`.