### PR TITLE
make parse_c module isolate

### DIFF
--- a/src/scripts/code_gen/cli.py
+++ b/src/scripts/code_gen/cli.py
@@ -76,6 +76,8 @@ def load_options(rebuild: bool) -> list[FFMpegOption]:
             type=FFMpegOptionType(i.type.value),
             flags=i.flags,
             help=i.help,
+            argname=i.argname,
+            canon=i.canon,
         )
         for i in parse_c.cli.parse_ffmpeg_options()
     ]

--- a/src/scripts/code_gen/cli.py
+++ b/src/scripts/code_gen/cli.py
@@ -15,6 +15,7 @@ from ffmpeg.common.schema import (
     FFMpegFilterOptionType,
     FFMpegIOType,
     FFMpegOption,
+    FFMpegOptionType,
     StreamType,
 )
 
@@ -69,7 +70,15 @@ def load_options(rebuild: bool) -> list[FFMpegOption]:
         except Exception as e:
             logging.error(f"Failed to load options from cache: {e}")
 
-    options = parse_c.cli.parse_ffmpeg_options()
+    options = [
+        FFMpegOption(
+            name=i.name,
+            type=FFMpegOptionType(i.type.value),
+            flags=i.flags,
+            help=i.help,
+        )
+        for i in parse_c.cli.parse_ffmpeg_options()
+    ]
     save(options, "options")
     return options
 

--- a/src/scripts/parse_c/cli.py
+++ b/src/scripts/parse_c/cli.py
@@ -11,10 +11,9 @@ from pathlib import Path
 
 import typer
 
-from ffmpeg.common.schema import FFMpegOption
-
 from .parse_ffmpeg_opt_c import parse_ffmpeg_opt_c
 from .pre_compile import precompile, target_folder
+from .schema import FFMpegOption
 from .xsd_to_dataclasses import generate_dataclasses, parse_xsd_file
 
 app = typer.Typer(help="Parse FFmpeg C source code")

--- a/src/scripts/parse_c/parse_ffmpeg_opt_c.py
+++ b/src/scripts/parse_c/parse_ffmpeg_opt_c.py
@@ -10,9 +10,8 @@ and other properties to build a structured representation of FFmpeg's CLI option
 import re
 from dataclasses import replace
 
-from ffmpeg.common.schema import FFMpegOption, FFMpegOptionFlag
-
 from .parse_c_structure import parse_c_structure
+from .schema import FFMpegOption, FFMpegOptionFlag
 
 
 def parse_ffmpeg_opt_c(text: str) -> list[FFMpegOption]:

--- a/src/scripts/parse_c/schema.py
+++ b/src/scripts/parse_c/schema.py
@@ -1,0 +1,196 @@
+"""Schema definitions for FFmpeg options."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class FFMpegOptionFlag(int, Enum):
+    """FFmpeg option flags that define option behavior and characteristics."""
+
+    OPT_FUNC_ARG = 1 << 0
+    """
+    The OPT_TYPE_FUNC option takes an argument.
+    Must not be used with other option types, as for those it holds:
+    - OPT_TYPE_BOOL do not take an argument
+    - all other types do
+    """
+
+    OPT_EXIT = 1 << 1
+    """
+    Program will immediately exit after processing this option
+    """
+
+    OPT_EXPERT = 1 << 2
+    """
+    Option is intended for advanced users. Only affects help output.
+    """
+
+    OPT_VIDEO = 1 << 3
+    OPT_AUDIO = 1 << 4
+    OPT_SUBTITLE = 1 << 5
+    OPT_DATA = 1 << 6
+
+    OPT_PERFILE = 1 << 7
+    """
+    The option is per-file (currently ffmpeg-only). At least one of OPT_INPUT or OPT_OUTPUT must be set when this flag is in use.
+    """
+
+    OPT_FLAG_OFFSET = 1 << 8
+    """
+    Option is specified as an offset in a passed optctx.
+    Always use as OPT_OFFSET in option definitions.
+    """
+
+    OPT_OFFSET = OPT_FLAG_OFFSET | OPT_PERFILE
+    """
+    Option is to be stored in a SpecifierOptList.
+    Always use as OPT_SPEC in option definitions.
+    """
+    OPT_FLAG_SPEC = 1 << 9
+    """
+    Option is to be stored in a SpecifierOptList.
+    Always use as OPT_SPEC in option definitions.
+    """
+
+    OPT_SPEC = OPT_FLAG_SPEC | OPT_OFFSET
+    """
+    Option applies per-stream (implies OPT_SPEC).
+    """
+    OPT_FLAG_PERSTREAM = 1 << 10
+    """
+    Option applies per-stream (implies OPT_SPEC).
+    """
+    OPT_PERSTREAM = OPT_FLAG_PERSTREAM | OPT_SPEC
+
+    OPT_INPUT = 1 << 11
+    """
+    ffmpeg-only - specifies whether an OPT_PERFILE option applies to input, output, or both.
+    """
+    OPT_OUTPUT = 1 << 12
+    """
+    ffmpeg-only - specifies whether an OPT_PERFILE option applies to input, output, or both.
+    """
+
+    OPT_HAS_ALT = 1 << 13
+    """
+    This option is a "canonical" form, to which one or more alternatives exist. These alternatives are listed in u1.names_alt.
+    """
+    OPT_HAS_CANON = 1 << 14
+    """
+    This option is an alternative form of some other option, whose name is stored in u1.name_canon
+    """
+
+
+class FFMpegOptionType(str, Enum):
+    """
+    Enumeration of FFmpeg option data types.
+
+    This enum defines the various data types that can be used for FFmpeg
+    command-line options. These types correspond to the internal option
+    types defined in FFmpeg's libavutil/opt.h header.
+    """
+
+    OPT_TYPE_FUNC = "OPT_TYPE_FUNC"
+    """Function option type, typically used for callback functions"""
+
+    OPT_TYPE_BOOL = "OPT_TYPE_BOOL"
+    """Boolean option type (true/false)"""
+
+    OPT_TYPE_STRING = "OPT_TYPE_STRING"
+    """String option type"""
+
+    OPT_TYPE_INT = "OPT_TYPE_INT"
+    """Integer option type"""
+
+    OPT_TYPE_INT64 = "OPT_TYPE_INT64"
+    """64-bit integer option type"""
+
+    OPT_TYPE_FLOAT = "OPT_TYPE_FLOAT"
+    """Floating-point option type"""
+
+    OPT_TYPE_DOUBLE = "OPT_TYPE_DOUBLE"
+    """Double-precision floating-point option type"""
+
+    OPT_TYPE_TIME = "OPT_TYPE_TIME"
+    """Time value option type (e.g., duration in seconds)"""
+
+
+@dataclass(frozen=True, kw_only=True)
+class FFMpegOption:
+    """
+    Represents a command-line option for FFmpeg.
+
+    This class defines the metadata for a single option that can be passed
+    to the FFmpeg command line, including its type, help text, and flags
+    that determine its behavior.
+    """
+
+    name: str
+    """The name of the option as used in FFmpeg commands"""
+
+    type: FFMpegOptionType
+    """The data type of the option (boolean, int, string, etc.)"""
+
+    flags: int
+    """Bitmap of FFMpegOptionFlag values that define the option's behavior"""
+
+    help: str
+    """Human-readable description of what the option does"""
+
+    argname: str | None = None
+    """Optional name for the option's argument in help text"""
+
+    canon: str | None = None
+    """For alternative option forms, the name of the canonical option"""
+
+    @property
+    def is_input_option(self) -> bool:
+        """
+        Check if this option applies to input files.
+
+        Returns:
+            True if this option is meant to be used with input files
+
+        """
+        return bool(self.flags & FFMpegOptionFlag.OPT_INPUT)
+
+    @property
+    def is_output_option(self) -> bool:
+        """
+        Check if this option applies to output files.
+
+        Returns:
+            True if this option is meant to be used with output files
+
+        """
+        return bool(self.flags & FFMpegOptionFlag.OPT_OUTPUT)
+
+    @property
+    def is_global_option(self) -> bool:
+        """
+        Check if this option applies globally rather than to specific files.
+
+        Returns:
+            True if this option is a global option that doesn't apply to
+            specific input or output files
+
+        """
+        return (
+            not self.is_input_option
+            and not self.is_output_option
+            and not (self.flags & FFMpegOptionFlag.OPT_EXIT)
+        )
+
+    @property
+    def is_support_stream_specifier(self) -> bool:
+        """
+        Check if this option supports stream specifiers.
+
+        Stream specifiers allow options to be applied to specific streams
+        within a file, using syntax like "-c:v" for video codec.
+
+        Returns:
+            True if this option can be used with stream specifiers
+
+        """
+        return bool(self.flags & FFMpegOptionFlag.OPT_SPEC)


### PR DESCRIPTION
This pull request introduces significant changes to improve the handling and representation of FFmpeg command-line options in the codebase. The most important updates include the addition of a new schema module defining `FFMpegOption` and related enums, refactoring imports to use the new schema, and enhancing the `load_options` function to utilize the updated `FFMpegOption` structure.

### Schema Enhancements:
* [`src/scripts/parse_c/schema.py`](diffhunk://#diff-364ddddb246c4033b07edafa7048b471cfa1b6bde159fd48c61dc9d2960c6935R1-R196): Added a new schema module defining `FFMpegOption`, `FFMpegOptionType`, and `FFMpegOptionFlag`. This provides a structured and extensible way to represent FFmpeg options, including properties for input/output/global options and stream specifier support.

### Refactoring for Schema Integration:
* [`src/scripts/parse_c/cli.py`](diffhunk://#diff-c89242ebfb08d30a18ae1c94bb6000087eb10c120af9a8a3fe6627b0be40084cL14-R16): Updated imports to use the new `schema.py` module for `FFMpegOption`, replacing the previous import from `ffmpeg.common.schema`.
* [`src/scripts/parse_c/parse_ffmpeg_opt_c.py`](diffhunk://#diff-f0e16dafab3951641147ccbca9f05d0417b61bcaf45e67fd28fe373ea2cb927fL13-R14): Refactored imports to use `schema.py` for `FFMpegOption` and `FFMpegOptionFlag`.

### Functional Improvements:
* [`src/scripts/code_gen/cli.py`](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L72-R81): Enhanced the `load_options` function to construct `FFMpegOption` objects using the new `FFMpegOptionType` enum and other schema properties, providing better type safety and clarity.

### Minor Updates:
* [`src/scripts/code_gen/cli.py`](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9R18): Added `FFMpegOptionType` to the list of imports for schema integration.