### PR TITLE
docs: add automated release script and update release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,13 +356,48 @@ uv lock --upgrade-package <package-name>
 
 ### Releasing a New Version
 
-Maintainers only:
+Maintainers only. The monorepo publishes **11 packages** to PyPI in dependency order:
 
-1. Update version in `pyproject.toml`
-2. Update CHANGELOG.md
-3. Create git tag: `git tag v0.x.x`
-4. Push tag: `git push origin v0.x.x`
-5. GitHub Actions will publish to PyPI
+| Layer | Packages |
+|-------|----------|
+| Core | `ffmpeg-core` |
+| Data | `ffmpeg-data-v5`, `ffmpeg-data-v6`, `ffmpeg-data-v7`, `ffmpeg-data-v8` |
+| Bindings | `typed-ffmpeg-v5`, `typed-ffmpeg-v6`, `typed-ffmpeg-v7`, `typed-ffmpeg-v8` |
+| Meta | `typed-ffmpeg` (latest), `typed-ffmpeg-compatible` |
+
+#### Automated Release
+
+The release script handles all steps interactively:
+
+```bash
+python scripts/release.py           # prompts for version
+python scripts/release.py 4.0.0     # skip version prompt
+python scripts/release.py --dry-run # preview without changes
+```
+
+The script will:
+1. Bump version across all 11 packages (via `scripts/bump-version.py`)
+2. Insert a new CHANGELOG.md section and open your `$EDITOR`
+3. Commit and create a git tag
+4. Push to origin (with confirmation)
+5. Create a GitHub Release via `gh` CLI (triggers `monorepo-publish.yml`)
+
+The publish workflow builds all packages and publishes to PyPI in dependency order:
+core → data → bindings → meta. Documentation is deployed automatically via `deploy-docs.yml` on version tags.
+
+#### Manual / Partial Publish
+
+You can also trigger the publish workflow manually from the Actions tab:
+- **`package`**: select specific packages (e.g. `core`, `v8`) or `all`
+- **`test-pypi`**: publish to TestPyPI first for validation (recommended for major releases)
+
+#### Adding a New FFmpeg Version (e.g. v9)
+
+1. Add a Docker image entry to `codegen-regenerate.yml`
+2. Run codegen to generate `packages/v9` and `packages/data-v9`
+3. Add the new packages to `scripts/bump-version.py` and the publish workflow
+4. Update the `typed-ffmpeg` meta-package dependency to point to the new version
+5. Bump version and release all packages
 
 ## Getting Help
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Automate the typed-ffmpeg monorepo release process.
+
+Steps:
+  1. Ask for new version
+  2. Bump all 11 package versions
+  3. Update CHANGELOG.md (open in $EDITOR)
+  4. Commit and tag
+  5. Push to remote
+  6. Create GitHub Release (triggers publish workflow)
+
+Usage:
+  python scripts/release.py
+  python scripts/release.py 4.0.0        # skip version prompt
+  python scripts/release.py --dry-run    # preview without making changes
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import textwrap
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+
+def run(cmd: list[str], *, check: bool = True, capture: bool = False, **kwargs) -> subprocess.CompletedProcess[str]:
+    print(f"  $ {' '.join(cmd)}")
+    return subprocess.run(cmd, check=check, capture_output=capture, text=True, cwd=REPO_ROOT, **kwargs)
+
+
+def get_current_version() -> str:
+    """Read current version from the core package pyproject.toml."""
+    toml = (REPO_ROOT / "packages" / "core" / "pyproject.toml").read_text()
+    for line in toml.splitlines():
+        if line.startswith("version = "):
+            return line.split('"')[1]
+    return "unknown"
+
+
+def ask(prompt: str, *, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    value = input(f"{prompt}{suffix}: ").strip()
+    return value or default
+
+
+def confirm(prompt: str) -> bool:
+    return input(f"{prompt} [y/N]: ").strip().lower() in ("y", "yes")
+
+
+def check_prerequisites() -> None:
+    """Verify git is clean and required tools exist."""
+    result = run(["git", "status", "--porcelain"], capture=True)
+    if result.stdout.strip():
+        print("\nWorking tree is not clean:")
+        print(result.stdout)
+        if not confirm("Continue anyway?"):
+            sys.exit(1)
+
+    # Check gh CLI is available
+    result = run(["gh", "--version"], capture=True, check=False)
+    if result.returncode != 0:
+        print("WARNING: gh CLI not found. GitHub Release will need to be created manually.")
+        print("  Install: https://cli.github.com/")
+
+
+def bump_version(version: str) -> None:
+    print(f"\n==> Bumping all packages to {version}")
+    run([sys.executable, str(REPO_ROOT / "scripts" / "bump-version.py"), version])
+
+
+def update_changelog(version: str) -> None:
+    print(f"\n==> Updating CHANGELOG.md")
+    today = date.today().isoformat()
+    header = f"## [{version}] - {today}"
+
+    text = CHANGELOG.read_text()
+    # Check if this version already has an entry
+    if f"## [{version}]" in text:
+        print(f"  CHANGELOG already has an entry for {version}")
+    else:
+        # Insert new section after the preamble
+        marker = "\n## ["
+        idx = text.find(marker)
+        if idx == -1:
+            print("  WARNING: Could not find existing version section in CHANGELOG.md")
+            return
+
+        template = textwrap.dedent(f"""\
+
+        {header}
+
+        ### Added
+
+        -
+
+        ### Changed
+
+        -
+
+        ### Fixed
+
+        -
+
+        """)
+        text = text[:idx] + template + text[idx:]
+        CHANGELOG.write_text(text)
+        print(f"  Inserted new section: {header}")
+
+    # Open in editor
+    import os
+    import shutil
+
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
+    if not editor:
+        for candidate in ("code --wait", "vim", "vi", "nano"):
+            name = candidate.split()[0]
+            if shutil.which(name):
+                editor = candidate
+                break
+
+    if editor and confirm(f"Open CHANGELOG.md in {editor.split()[0]}?"):
+        run(editor.split() + [str(CHANGELOG)], check=False)
+    else:
+        print(f"  Please edit {CHANGELOG} manually, then press Enter to continue.")
+        input("  Press Enter when done...")
+
+
+def commit_and_tag(version: str) -> None:
+    tag = f"v{version}"
+    print(f"\n==> Committing and tagging as {tag}")
+    run(["git", "add", "-A"])
+    run(["git", "commit", "-m", f"release: {tag}"])
+    run(["git", "tag", tag])
+
+
+def push(version: str) -> None:
+    tag = f"v{version}"
+    print(f"\n==> Pushing to remote")
+    result = run(["git", "remote", "get-url", "origin"], capture=True)
+    remote_url = result.stdout.strip()
+    print(f"  Remote: {remote_url}")
+
+    if not confirm(f"Push commit and tag {tag} to origin?"):
+        print("  Skipped. Run manually:")
+        print(f"    git push origin main --tags")
+        return False
+    run(["git", "push", "origin", "main", "--tags"])
+    return True
+
+
+def create_github_release(version: str) -> None:
+    tag = f"v{version}"
+    print(f"\n==> Creating GitHub Release for {tag}")
+
+    # Extract changelog section for this version
+    text = CHANGELOG.read_text()
+    start = text.find(f"## [{version}]")
+    if start == -1:
+        notes = ""
+    else:
+        # Find the next ## section
+        next_section = text.find("\n## [", start + 1)
+        section = text[start:next_section].strip() if next_section != -1 else text[start:].strip()
+        # Remove the header line
+        lines = section.splitlines()
+        notes = "\n".join(lines[1:]).strip()
+
+    if not notes:
+        print("  WARNING: No changelog notes found for this version")
+        notes = f"Release {tag}"
+
+    pre_release = "a" in version or "b" in version or "rc" in version
+    cmd = ["gh", "release", "create", tag, "--title", tag, "--notes", notes]
+    if pre_release:
+        cmd.append("--prerelease")
+
+    if not confirm(f"Create GitHub Release {tag}{'  (pre-release)' if pre_release else ''}?"):
+        print("  Skipped. Run manually:")
+        print(f"    gh release create {tag}")
+        return
+
+    result = run(cmd, check=False)
+    if result.returncode != 0:
+        print("  Failed to create release. Create it manually at:")
+        print(f"    https://github.com/livingbio/typed-ffmpeg/releases/new?tag={tag}")
+    else:
+        print(f"  Release created. This triggers the publish workflow.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Release typed-ffmpeg monorepo packages")
+    parser.add_argument("version", nargs="?", help="New version (e.g. 4.0.0)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview steps without making changes")
+    args = parser.parse_args()
+
+    current = get_current_version()
+    print(f"typed-ffmpeg release script")
+    print(f"Current version: {current}")
+
+    if args.dry_run:
+        print("\n[DRY RUN] Would perform:")
+        print("  1. Bump all 11 package versions")
+        print("  2. Update CHANGELOG.md")
+        print("  3. Commit and tag")
+        print("  4. Push to origin")
+        print("  5. Create GitHub Release (triggers PyPI publish)")
+        return
+
+    # Step 1: Get version
+    version = args.version
+    if not version:
+        version = ask("New version", default="")
+        if not version:
+            print("No version provided. Aborting.")
+            sys.exit(1)
+
+    print(f"\nWill release: {current} -> {version}")
+    if not confirm("Proceed?"):
+        sys.exit(0)
+
+    # Step 2: Check prerequisites
+    check_prerequisites()
+
+    # Step 3: Bump versions
+    bump_version(version)
+
+    # Step 4: Update changelog
+    update_changelog(version)
+
+    # Step 5: Commit and tag
+    commit_and_tag(version)
+
+    # Step 6: Push
+    pushed = push(version)
+
+    # Step 7: Create GitHub Release
+    if pushed:
+        create_github_release(version)
+    else:
+        print("\n  Skipping GitHub Release (not pushed yet).")
+        print(f"  After pushing, run: gh release create v{version}")
+
+    print("\n==> Done!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/release.py` that automates the full monorepo release flow interactively (bump versions → update changelog → commit/tag → push → create GitHub Release)
- Update the "Releasing a New Version" section in CONTRIBUTING.md to reflect the monorepo structure (11 packages, dependency-ordered publishing, manual/partial publish options, new FFmpeg version instructions)

## Test plan
- [ ] `python scripts/release.py --dry-run` previews steps without side effects
- [ ] `python scripts/release.py 4.0.0` walks through the full interactive release flow
- [ ] Verify CONTRIBUTING.md release docs are accurate against `monorepo-publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)