### PR TITLE
fix: resolve no-useless-assignment lint errors for eslint/js 10 compa…

### DIFF
--- a/packages/playground/src/utils/formulaEvaluator.ts
+++ b/packages/playground/src/utils/formulaEvaluator.ts
@@ -101,7 +101,7 @@ class PythonExprParser {
     let left = this.parseAdd();
     this.skipWS();
     while (true) {
-      let op: string | null = null;
+      let op: string;
       if (this.match('==')) op = '===';
       else if (this.match('!=')) op = '!==';
       else if (this.match('<=')) op = '<=';

--- a/packages/playground/src/utils/nodeMapping.ts
+++ b/packages/playground/src/utils/nodeMapping.ts
@@ -161,24 +161,18 @@ export class NodeMappingManager {
       }
     });
     parameters = { ...parameters, ...kwargs };
-    let input_typings: StreamTypeEnum[] = [];
-    if (!filter.formula_typings_input) {
-      input_typings = filter.stream_typings_input.map((t) => t.type.value);
-    } else {
-      input_typings = await evaluateFormula(
-        filter.formula_typings_input,
-        parameters,
-      );
-    }
-    let output_typings: StreamTypeEnum[] = [];
-    if (!filter.formula_typings_output) {
-      output_typings = filter.stream_typings_output.map((t) => t.type.value);
-    } else {
-      output_typings = await evaluateFormula(
-        filter.formula_typings_output,
-        parameters,
-      );
-    }
+    const input_typings: StreamTypeEnum[] = !filter.formula_typings_input
+      ? filter.stream_typings_input.map((t) => t.type.value)
+      : await evaluateFormula(
+          filter.formula_typings_input,
+          parameters,
+        );
+    const output_typings: StreamTypeEnum[] = !filter.formula_typings_output
+      ? filter.stream_typings_output.map((t) => t.type.value)
+      : await evaluateFormula(
+          filter.formula_typings_output,
+          parameters,
+        );
     return {
       input_typings,
       output_typings,


### PR DESCRIPTION
…tibility

Remove unused variable initializations flagged by the no-useless-assignment rule introduced in @eslint/js 10.0.1. These fixes are backward-compatible with eslint 9.

https://claude.ai/code/session_011TnzfUxK1NzDzijG43ZGEu