### PR TITLE
docs: update project descriptions for TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/typed-ffmpeg.svg)](https://pypi.org/project/typed-ffmpeg/)
 [![codecov](https://codecov.io/gh/livingbio/typed-ffmpeg/graph/badge.svg?token=B95PR629LP)](https://codecov.io/gh/livingbio/typed-ffmpeg)
 
-**typed-ffmpeg** offers a modern, Pythonic interface to FFmpeg, providing extensive support for complex filters with detailed typing and documentation. Inspired by `ffmpeg-python`, this package enhances functionality by addressing common limitations, such as lack of IDE integration and comprehensive typing, while also introducing new features like JSON serialization of filter graphs and automatic FFmpeg validation.
+**typed-ffmpeg** offers a modern, type-safe interface to FFmpeg for both **Python** and **TypeScript**, providing extensive support for complex filters with detailed typing and documentation. Inspired by `ffmpeg-python`, this project enhances functionality by addressing common limitations, such as lack of IDE integration and comprehensive typing, while also introducing new features like JSON serialization of filter graphs and automatic FFmpeg validation.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,228 @@
+# TypeScript Bindings
+
+typed-ffmpeg provides type-safe FFmpeg bindings for TypeScript, mirroring the Python API with idiomatic TypeScript patterns. Every filter method includes full JSDoc documentation and IDE autocomplete support.
+
+## Packages
+
+| npm Package | FFmpeg Version | Install |
+|---|---|---|
+| `@typed-ffmpeg/v8` | FFmpeg 8.x | `npm install @typed-ffmpeg/core @typed-ffmpeg/v8` |
+| `@typed-ffmpeg/v7` | FFmpeg 7.x | `npm install @typed-ffmpeg/core @typed-ffmpeg/v7` |
+| `@typed-ffmpeg/v6` | FFmpeg 6.x | `npm install @typed-ffmpeg/core @typed-ffmpeg/v6` |
+| `@typed-ffmpeg/v5` | FFmpeg 5.x | `npm install @typed-ffmpeg/core @typed-ffmpeg/v5` |
+| `@typed-ffmpeg/core` | — | Core runtime (auto-required by version packages) |
+
+**For most users:** install `@typed-ffmpeg/core` and the version package matching your FFmpeg installation.
+
+### Requirements
+
+- Node.js >= 18
+- FFmpeg installed on your system (only needed for `.run()` — graph compilation works without it)
+
+### Builds
+
+`@typed-ffmpeg/core` ships three builds, selected automatically via the `exports` field:
+
+- **CJS** — Node.js default (`require`)
+- **ESM** — Node.js ESM (`import`)
+- **Browser ESM** — browser-safe bundle
+
+## Quick Start
+
+```typescript
+import { input } from "@typed-ffmpeg/v8";
+
+// Scale and flip a video
+const cmd = input("input.mp4")
+  .video
+  .hflip()
+  .scale({ w: 1280, h: 720 })
+  .output("output.mp4")
+  .overwriteOutput();
+
+// Get the FFmpeg command line
+console.log(cmd.compileLine());
+
+// Or get arguments as a list
+const args = cmd.compile();
+```
+
+## Usage Examples
+
+### Simple Transcode
+
+```typescript
+import { input, output } from "@typed-ffmpeg/v8";
+
+const cmd = output(
+  [input("input.mp4")],
+  "output.mp4",
+  { vcodec: "libx264" },
+).overwriteOutput();
+
+console.log(cmd.compileLine());
+```
+
+### Video Filters
+
+Filter methods are available directly on stream objects with full type safety:
+
+```typescript
+import { input, InputNode, FilterNode, StreamType } from "@typed-ffmpeg/v8";
+
+const inp = new InputNode("input.mp4");
+
+// Chain filters — each method returns a typed stream
+const filtered = inp.video
+  .hflip()
+  .scale({ w: 640, h: 480 })
+  .drawbox({ x: 10, y: 10, w: 100, h: 100, color: "red", thickness: 3 });
+
+const cmd = filtered
+  .output("filtered.mp4")
+  .overwriteOutput();
+```
+
+### Audio Processing
+
+```typescript
+import { InputNode, FilterNode, OutputNode, StreamType } from "@typed-ffmpeg/v8";
+
+const inp = new InputNode("input.mp4");
+
+const volume = new FilterNode(
+  "volume",
+  [inp.audio],
+  { volume: 0.5 },
+  [StreamType.Audio],
+  [StreamType.Audio],
+);
+
+const echo = new FilterNode(
+  "aecho",
+  [volume.audio(0)],
+  { in_gain: 0.8, out_gain: 0.88, delays: 60, decays: 0.4 },
+  [StreamType.Audio],
+  [StreamType.Audio],
+);
+
+const cmd = new OutputNode([echo.audio(0)], "audio_out.mp4")
+  .stream()
+  .overwriteOutput();
+```
+
+### Overlay
+
+```typescript
+import { InputNode, FilterNode, OutputNode, StreamType } from "@typed-ffmpeg/v8";
+
+const main = new InputNode("main.mp4");
+const logo = new InputNode("logo.png");
+
+const overlay = new FilterNode(
+  "overlay",
+  [main.video, logo.video],
+  { x: 10, y: 10 },
+  [StreamType.Video, StreamType.Video],
+  [StreamType.Video],
+);
+
+const cmd = new OutputNode([overlay.video(0)], "with_logo.mp4")
+  .stream()
+  .overwriteOutput();
+```
+
+### Multiple Outputs
+
+```typescript
+import { InputNode, FilterNode, OutputNode, StreamType, mergeOutputs } from "@typed-ffmpeg/v8";
+
+const inp = new InputNode("input.mp4");
+
+const hd = new FilterNode("scale", [inp.video], { w: 1920, h: 1080 },
+  [StreamType.Video], [StreamType.Video]);
+const sd = new FilterNode("scale", [inp.video], { w: 1280, h: 720 },
+  [StreamType.Video], [StreamType.Video]);
+
+const cmd = mergeOutputs(
+  new OutputNode([hd.video(0)], "1080p.mp4").stream(),
+  new OutputNode([sd.video(0)], "720p.mp4").stream(),
+);
+
+console.log(cmd.compileLine());
+```
+
+### Input Options
+
+```typescript
+import { input, output } from "@typed-ffmpeg/v8";
+
+// Seek to 1 minute and take 30 seconds
+const clip = input("long_video.mp4", { ss: "00:01:00", t: "00:00:30" });
+const cmd = output([clip], "clip.mp4").overwriteOutput();
+```
+
+### Compile to Argument List
+
+```typescript
+import { input } from "@typed-ffmpeg/v8";
+
+const cmd = input("input.mp4")
+  .video
+  .scale({ w: 640, h: 480 })
+  .output("small.mp4")
+  .overwriteOutput();
+
+// Get arguments as string[]
+const args: string[] = cmd.compile();
+// => ["-i", "input.mp4", "-filter_complex", "...", "small.mp4", "-y"]
+```
+
+## API Overview
+
+### Core Exports (`@typed-ffmpeg/core`)
+
+| Export | Description |
+|---|---|
+| `InputNode` | Represents an FFmpeg input (`-i`) |
+| `OutputNode` | Represents an FFmpeg output |
+| `FilterNode` | Represents a filter in the graph |
+| `VideoStream` / `AudioStream` | Typed stream references |
+| `mergeOutputs()` | Combine multiple outputs into one command |
+| `compile()` / `compileAsList()` | Compile a DAG to FFmpeg arguments |
+| `validate()` / `fixGraph()` | Validate and auto-correct filter graphs |
+| `run()` / `runAsync()` | Execute FFmpeg commands |
+| `StreamType` | Enum: `Video`, `Audio` |
+
+### Version Exports (`@typed-ffmpeg/v5` – `v8`)
+
+Each version package re-exports core types and adds:
+
+| Export | Description |
+|---|---|
+| `input()` | Typed input function with all FFmpeg input options |
+| `output()` | Typed output function with all FFmpeg output options |
+| `VideoStream` / `AudioStream` | Stream classes with typed filter methods (`.scale()`, `.hflip()`, etc.) |
+| `filters` | All filter functions as a namespace |
+| `sources` | Source filter functions (no input streams required) |
+| `codecs` / `decoders` | Codec option factories |
+| `muxers` / `demuxers` | Format option factories |
+
+## Differences from the Python API
+
+| Aspect | Python | TypeScript |
+|---|---|---|
+| Filter arguments | Keyword arguments: `stream.scale(w=1280, h=720)` | Options object: `stream.scale({ w: 1280, h: 720 })` |
+| Package manager | pip / PyPI | npm |
+| Module import | `import ffmpeg` | `import { input } from "@typed-ffmpeg/v8"` |
+| Execution | `ffmpeg.run()` | `run()` / `runAsync()` |
+
+## Demo Project
+
+A complete demo project is available at [`examples/typescript-demo/`](https://github.com/livingbio/typed-ffmpeg/tree/main/examples/typescript-demo) with 8 working examples covering all major use cases.
+
+```bash
+cd examples/typescript-demo
+npm install
+npm run dev
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: typed-ffmpeg
-site_description: Data validation using Python type hints
+site_description: Type-safe FFmpeg bindings for Python & TypeScript
 strict: false
 site_url: https://livingbio.github.io/typed-ffmpeg/
 
@@ -71,6 +71,7 @@ nav:
       - Version Differences: version-differences.md
       - FAQ: faq.md
       - Migration from 3.x: migration/v3-to-v4.md
+  - TypeScript: typescript.md
   - Usage:
       - Basic API Usage: usage/basic-api-usage.ipynb
       - Probe: usage/probe.ipynb

--- a/packages/latest/pyproject.toml
+++ b/packages/latest/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "typed-ffmpeg"
 version = "4.0.0"
-description = "Modern Python FFmpeg wrappers with comprehensive typing (latest version)"
+description = "Modern Python & TypeScript FFmpeg wrappers with comprehensive typing (latest version)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
 ]

--- a/packages/ts-core/README.md
+++ b/packages/ts-core/README.md
@@ -1,0 +1,32 @@
+# @typed-ffmpeg/core
+
+Core runtime for typed-ffmpeg TypeScript bindings.
+
+Provides the DAG model, compilation pipeline, validation, and execution utilities for building type-safe FFmpeg filter graphs in TypeScript.
+
+## Installation
+
+```bash
+npm install @typed-ffmpeg/core
+```
+
+This package is automatically installed as a dependency of the version-specific packages (`@typed-ffmpeg/v5` through `@typed-ffmpeg/v8`). Most users should install a version package directly rather than using `@typed-ffmpeg/core` alone.
+
+## Builds
+
+Three builds are shipped, selected automatically via the `exports` field:
+
+- **CJS** — `dist/index.js` (Node.js default)
+- **ESM** — `dist/esm/index.js` (Node.js ESM)
+- **Browser** — `dist/browser/index.browser.js` (browser-safe ESM)
+
+## Key Exports
+
+- `InputNode`, `OutputNode`, `FilterNode` — DAG node types
+- `VideoStream`, `AudioStream`, `AVStream` — Stream types
+- `compile()`, `compileAsList()` — Compile filter graphs to FFmpeg arguments
+- `validate()`, `fixGraph()` — Validate and auto-correct filter graphs
+- `run()`, `runAsync()` — Execute FFmpeg commands
+- `StreamType` — Enum for stream types (Video, Audio)
+
+See the [TypeScript documentation](https://livingbio.github.io/typed-ffmpeg/typescript/) for usage examples.

--- a/packages/ts-v5/README.md
+++ b/packages/ts-v5/README.md
@@ -1,0 +1,27 @@
+# @typed-ffmpeg/v5
+
+Type-safe FFmpeg 5.x bindings for TypeScript.
+
+## Installation
+
+```bash
+npm install @typed-ffmpeg/core @typed-ffmpeg/v5
+```
+
+## Usage
+
+```typescript
+import { input } from "@typed-ffmpeg/v5";
+
+const cmd = input("input.mp4")
+  .video
+  .scale({ w: 1280, h: 720 })
+  .output("output.mp4")
+  .overwriteOutput();
+
+console.log(cmd.compileLine());
+```
+
+All filter methods include JSDoc annotations indicating availability across FFmpeg versions.
+
+See the [TypeScript documentation](https://livingbio.github.io/typed-ffmpeg/typescript/) for more examples.

--- a/packages/ts-v6/README.md
+++ b/packages/ts-v6/README.md
@@ -1,0 +1,27 @@
+# @typed-ffmpeg/v6
+
+Type-safe FFmpeg 6.x bindings for TypeScript.
+
+## Installation
+
+```bash
+npm install @typed-ffmpeg/core @typed-ffmpeg/v6
+```
+
+## Usage
+
+```typescript
+import { input } from "@typed-ffmpeg/v6";
+
+const cmd = input("input.mp4")
+  .video
+  .scale({ w: 1280, h: 720 })
+  .output("output.mp4")
+  .overwriteOutput();
+
+console.log(cmd.compileLine());
+```
+
+All filter methods include JSDoc annotations indicating availability across FFmpeg versions.
+
+See the [TypeScript documentation](https://livingbio.github.io/typed-ffmpeg/typescript/) for more examples.

--- a/packages/ts-v7/README.md
+++ b/packages/ts-v7/README.md
@@ -1,0 +1,27 @@
+# @typed-ffmpeg/v7
+
+Type-safe FFmpeg 7.x bindings for TypeScript.
+
+## Installation
+
+```bash
+npm install @typed-ffmpeg/core @typed-ffmpeg/v7
+```
+
+## Usage
+
+```typescript
+import { input } from "@typed-ffmpeg/v7";
+
+const cmd = input("input.mp4")
+  .video
+  .scale({ w: 1280, h: 720 })
+  .output("output.mp4")
+  .overwriteOutput();
+
+console.log(cmd.compileLine());
+```
+
+All filter methods include JSDoc annotations indicating availability across FFmpeg versions.
+
+See the [TypeScript documentation](https://livingbio.github.io/typed-ffmpeg/typescript/) for more examples.

--- a/packages/ts-v8/README.md
+++ b/packages/ts-v8/README.md
@@ -1,0 +1,27 @@
+# @typed-ffmpeg/v8
+
+Type-safe FFmpeg 8.x bindings for TypeScript.
+
+## Installation
+
+```bash
+npm install @typed-ffmpeg/core @typed-ffmpeg/v8
+```
+
+## Usage
+
+```typescript
+import { input } from "@typed-ffmpeg/v8";
+
+const cmd = input("input.mp4")
+  .video
+  .scale({ w: 1280, h: 720 })
+  .output("output.mp4")
+  .overwriteOutput();
+
+console.log(cmd.compileLine());
+```
+
+All filter methods include JSDoc annotations indicating availability across FFmpeg versions.
+
+See the [TypeScript documentation](https://livingbio.github.io/typed-ffmpeg/typescript/) for more examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ members = [
 [project]
 name = "typed-ffmpeg-workspace"
 version = "0.0.0"
-description = "Monorepo root for typed-ffmpeg (workspace + dev scripts)"
+description = "Monorepo root for typed-ffmpeg — type-safe FFmpeg bindings for Python & TypeScript"
 dependencies = [
     "ffmpeg-core",
     "ffmpeg-data-v5",


### PR DESCRIPTION
## Summary
- Update project descriptions across README, pyproject.toml, mkdocs.yml, and GitHub repo metadata to reflect TypeScript support
- Add dedicated TypeScript documentation page (`docs/typescript.md`) with installation, usage examples, and API overview
- Add README files for all TypeScript packages (`@typed-ffmpeg/core`, `v5`–`v8`)
- Fix mkdocs site description (was "Data validation using Python type hints")
- Add `typescript`, `npm`, `ffmpeg-typescript` topics to GitHub repo

## Test plan
- [ ] Verify mkdocs builds successfully with the new TypeScript nav entry
- [ ] Review `docs/typescript.md` renders correctly
- [ ] Confirm GitHub repo description and topics are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)