### PR TITLE
fix: bump to 4.0.1 and update bump-version.py to sync dependency constraints

### DIFF
--- a/packages/compatible/pyproject.toml
+++ b/packages/compatible/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-compatible"
-version = "4.0.0"
+version = "4.0.1"
 description = "typed-ffmpeg under the typed_ffmpeg module name (no conflict with ffmpeg-python)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -34,7 +34,7 @@ classifiers = [
 # as `typed_ffmpeg` so it doesn't conflict with ffmpeg-python's
 # `ffmpeg` module.
 dependencies = [
-    "typed-ffmpeg-v8>=4.0.0,<5.0",
+    "typed-ffmpeg-v8>=4.0.1,<5.0",
 ]
 
 [build-system]

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-core"
-version = "4.0.0"
+version = "4.0.1"
 description = "Core runtime for typed-ffmpeg (DAG, compilation, IR layer)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v5/pyproject.toml
+++ b/packages/data-v5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v5"
-version = "4.0.0"
+version = "4.0.1"
 description = "Cache data files for typed-ffmpeg-v5 (FFmpeg 5.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v6/pyproject.toml
+++ b/packages/data-v6/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v6"
-version = "4.0.0"
+version = "4.0.1"
 description = "Cache data files for typed-ffmpeg-v6 (FFmpeg 6.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v7/pyproject.toml
+++ b/packages/data-v7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v7"
-version = "4.0.0"
+version = "4.0.1"
 description = "Cache data files for typed-ffmpeg-v7 (FFmpeg 7.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v8/pyproject.toml
+++ b/packages/data-v8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v8"
-version = "4.0.0"
+version = "4.0.1"
 description = "Cache data files for typed-ffmpeg-v8 (FFmpeg 8.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/latest/pyproject.toml
+++ b/packages/latest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg"
-version = "4.0.0"
+version = "4.0.1"
 description = "Modern Python & TypeScript FFmpeg wrappers with comprehensive typing (latest version)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -33,7 +33,7 @@ classifiers = [
 # Meta-package: no source code, just depends on typed-ffmpeg-v8
 # which provides `import ffmpeg` directly.
 dependencies = [
-    "typed-ffmpeg-v8>=4.0.0,<5.0",
+    "typed-ffmpeg-v8>=4.0.1,<5.0",
 ]
 
 [tool.uv.sources]

--- a/packages/v5/pyproject.toml
+++ b/packages/v5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v5"
-version = "4.0.0"
+version = "4.0.1"
 description = "Typed FFmpeg bindings for FFmpeg 5.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-dependencies = ["ffmpeg-core>=4.0.0,<5.0"]
+dependencies = ["ffmpeg-core>=4.0.1,<5.0"]
 
 [tool.uv.sources]
 ffmpeg-core = { workspace = true }

--- a/packages/v6/pyproject.toml
+++ b/packages/v6/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v6"
-version = "4.0.0"
+version = "4.0.1"
 description = "Typed FFmpeg bindings for FFmpeg 6.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-dependencies = ["ffmpeg-core>=4.0.0,<5.0"]
+dependencies = ["ffmpeg-core>=4.0.1,<5.0"]
 
 [tool.uv.sources]
 ffmpeg-core = { workspace = true }

--- a/packages/v7/pyproject.toml
+++ b/packages/v7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v7"
-version = "4.0.0"
+version = "4.0.1"
 description = "Typed FFmpeg bindings for FFmpeg 7.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-dependencies = ["ffmpeg-core>=4.0.0,<5.0"]
+dependencies = ["ffmpeg-core>=4.0.1,<5.0"]
 
 [tool.uv.sources]
 ffmpeg-core = { workspace = true }

--- a/packages/v8/pyproject.toml
+++ b/packages/v8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v8"
-version = "4.0.0"
+version = "4.0.1"
 description = "Typed FFmpeg bindings for FFmpeg 8.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ffmpeg-core>=4.0.0,<5.0",
+    "ffmpeg-core>=4.0.1,<5.0",
 ]
 
 [tool.uv.sources]

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -8,12 +8,37 @@ from pathlib import Path
 PACKAGES = ["core", "data-v5", "data-v6", "data-v7", "data-v8", "v5", "v6", "v7", "v8", "latest", "compatible"]
 REPO_ROOT = Path(__file__).parent.parent
 
+# Internal packages whose dependency constraints should be updated
+INTERNAL_DEPS = ["ffmpeg-core", "typed-ffmpeg-v8"]
+
+
+def _version_constraint(version: str) -> str:
+    """Compute a compatible version constraint from a version string.
+
+    For version "4.0.0" or "4.0.1" returns ">=4.0.0,<5.0".
+    For pre-release "4.0.0a1" returns ">=4.0.0a1,<5.0".
+    """
+    major = version.split(".")[0]
+    next_major = int(major) + 1
+    return f">={version},<{next_major}.0"
+
 
 def bump(version: str) -> None:
+    constraint = _version_constraint(version)
+
     for pkg in PACKAGES:
         path = REPO_ROOT / "packages" / pkg / "pyproject.toml"
         text = path.read_text()
         updated = re.sub(r'^version = ".*"', f'version = "{version}"', text, count=1, flags=re.MULTILINE)
+
+        # Also update internal dependency constraints
+        for dep in INTERNAL_DEPS:
+            updated = re.sub(
+                rf'"{re.escape(dep)}>=.*?"',
+                f'"{dep}{constraint}"',
+                updated,
+            )
+
         if text == updated:
             print(f"  WARN: no version line found in packages/{pkg}/pyproject.toml")
         else:


### PR DESCRIPTION
The bump-version.py script only updated version fields but not inter-package
dependency constraints, causing typed-ffmpeg 4.0.0 on PyPI to depend on
typed-ffmpeg-v8>=1.0,<2.0 which is unsatisfiable. The script now automatically
updates internal dependency constraints (ffmpeg-core, typed-ffmpeg-v8) when
bumping versions.

Fixes #919

https://claude.ai/code/session_01LRog6Bmq2WAyCfHdyUAUA3