### PR TITLE
fix(ci): validate package versions match release tag before publishing

### DIFF
--- a/.github/workflows/monorepo-publish.yml
+++ b/.github/workflows/monorepo-publish.yml
@@ -37,6 +37,31 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Validate package versions match tag
+        if: github.event_name == 'release'
+        run: |
+          TAG="${{ github.ref_name }}"
+          EXPECTED="${TAG#v}"
+          echo "Release tag: $TAG — expected package version: $EXPECTED"
+
+          FAIL=0
+          for pkg in core data-v5 data-v6 data-v7 data-v8 v5 v6 v7 v8 latest compatible; do
+            PKG_VER=$(grep '^version = ' packages/$pkg/pyproject.toml | cut -d'"' -f2)
+            if [ "$PKG_VER" != "$EXPECTED" ]; then
+              echo "❌ packages/$pkg: $PKG_VER != $EXPECTED"
+              FAIL=1
+            else
+              echo "✅ packages/$pkg: $PKG_VER"
+            fi
+          done
+
+          if [ "$FAIL" = "1" ]; then
+            echo ""
+            echo "ERROR: Package versions do not match release tag '$TAG'."
+            echo "Run: python scripts/bump-version.py $EXPECTED, commit, re-tag, and re-publish."
+            exit 1
+          fi
+
       - name: Determine packages to publish
         id: packages
         run: |


### PR DESCRIPTION
## Summary

- Adds a pre-publish validation step in `monorepo-publish.yml` that checks every package's `pyproject.toml` version matches the release tag (e.g., tag `v4.1` requires all packages to be at `4.1`)
- Fails fast with a clear error and remediation instructions before any build or upload occurs

## Root cause (v4.1 failure)

The `v4.1` tag was manually pushed onto commit `616ff8c`, which still had package version `4.0.2`. PyPI returned `400 Bad Request` because `4.0.2` was already published. Without this guard the workflow wasted time building all packages before hitting the error.

## Test plan

- [ ] Verify workflow passes when tag and package versions match
- [ ] Verify workflow fails early with a clear message when they don't match

🤖 Generated with [Claude Code](https://claude.com/claude-code)