### PR TITLE
fix(ci): repair three broken workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # packages/playground lints with typescript-eslint, whose 8.x peer range
+      # caps TypeScript at <6.1.0. Bumping TypeScript to 7.x here makes every
+      # `npm install` in the workspace fail with ERESOLVE. Drop this once
+      # typescript-eslint ships TypeScript 7 support.
+      - dependency-name: "typescript"
+        versions: [">=7"]
   - package-ecosystem: "npm"
     directory: "/packages/ts-core"
     schedule:

--- a/.github/workflows/ci-monorepo-test.yml
+++ b/.github/workflows/ci-monorepo-test.yml
@@ -33,7 +33,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       
       - name: Install FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version
       
       - name: Install core package
         run: |
@@ -107,7 +110,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version
 
       - name: Install packages and run shared tests
         run: |
@@ -144,7 +150,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version
 
       - name: Test imports and build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -207,7 +207,9 @@ out/
 # Vite
 .vite/
 output.mp4
-ffmpeg/
+# Root-level FFmpeg source checkout only — must stay anchored, otherwise it
+# also matches the generated bindings in packages/v*/src/ffmpeg/.
+/ffmpeg/
 .claude/settings.local.json
 .claude/memory/
 docs/_stubs/

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -31,7 +31,7 @@
     "lint-staged": "^17.0.2",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
-    "typescript": "~7.0.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.57.1",
     "vite": "^8.0.1",
     "vitest": "^4.0.3"


### PR DESCRIPTION
Three workflows have been red on `main` since a3136908, each for an independent reason. Every root cause was reproduced locally before fixing.

## 1. `CI Monorepo - Test` — the ffmpeg action is dead

`FedericoCarboni/setup-ffmpeg@v3` resolves `release` by scraping johnvansickle.com. That lookup no longer works:

- on a3136908: `AssertionError: Failed to get latest johnvansickle ffmpeg release`
- on the most recent run: `AssertionError: Failed to read version from readme`

Every run since has died at that step. Replaced all three uses with `apt-get install -y ffmpeg`.

**Trade-off:** ffmpeg goes from a floating ~8.x to Ubuntu's **6.1.1**. Verified safe rather than assumed — the only binary-dependent tests are `test_info.py` (`len > 0` / `isinstance`) and `test_probe.py` (structural key checks; its snapshot lines are deliberately non-asserting, per the in-code comment *"the result is not stable so, we just want to record the result"*). `packages/tests-shared` never invokes ffmpeg at all — its only `subprocess` calls are pyright.

If we'd rather keep 8.x parity, the alternative is the Docker-extraction step already used by the green `ci-codegen-versions.yml` (`jrottenberg/ffmpeg:8.0-ubuntu`) — same pattern, proven in this repo, but adds a docker pull to each of 9 jobs. Happy to switch.

## 2. `CI TypeScript - Test` + `CI Playground - Test` — npm ERESOLVE

7810224d bumped `packages/playground` to `typescript: ~7.0.2`, but `typescript-eslint@8.x` peers on `typescript >=4.8.4 <6.1.0` — still true at latest (8.67.0). Because playground is an npm workspace member, **every** `npm install` in the repo failed, including `packages/ts-core`. That PR's own CI failed and it was merged anyway.

Reverted playground to `~6.0.3` and added a Dependabot `ignore` on the root npm entry so it doesn't get re-bumped. The `packages/ts-*` entries are untouched and keep managing their own TypeScript.

## 3. `CodeGen - Regenerate Bindings` — `git add` on ignored paths

`.gitignore` had an unanchored `ffmpeg/`, which also matched `packages/v*/src/ffmpeg/` — the generated bindings themselves. So `git add packages/v5/src/ffmpeg/ …` exits 1.

Anchored it to `/ffmpeg/`. The root-level FFmpeg checkout it was meant for is still ignored, and `src/scripts/parse_c/.gitignore` covers the parser's clone independently.

This is the same bug `regen-bindings.yml:169` papers over with `git add -f`, and it was silently dropping newly generated files from the `git add -A` in `ci-codegen-versions.yml:226`.

## Verification

On a clean clone with the fixes applied:

| Check | Result |
|---|---|
| `git add packages/v{5,6,7,8}/src/ffmpeg/ …` | exit 0 (was exit 1) |
| `npm install` | 386 packages, no ERESOLVE (was ERESOLVE) |
| ts-core build + `tsc --noEmit` + vitest | 153 passed |
| `tsc --noEmit` on ts-v5/v6/v7/v8 | all exit 0 |
| playground lint / build / vitest | exit 0, exit 0, 106 passed |
| `packages/core` suite vs ffmpeg **6.1.1** (`ubuntu:24.04` container) | **133 passed, 0 failed** |
| `prek run --files <changed>` | all hooks pass |

## Follow-ups, not in this PR

- `regen-bindings.yml:169` — the `-f` is now redundant, and slightly risky since it force-adds genuinely ignored files like `__pycache__`.
- `test-versions` matrix labels jobs `v5`…`v8` but runs them all against a single ffmpeg binary. Version-matched images would make the matrix mean what it says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvT2bzCPzJsK3wVa5BTBT