### PR TITLE
fix(deps): bump GitPython to 3.1.59 to clear 9 Dependabot alerts

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.11' and python_full_version < '3.15' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.15' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.11' and python_full_version < '3.15' and platform_python_implementation != 'PyPy'",
     "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
     "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
@@ -608,14 +608,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.54"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/d5/3da0b92033887033f4c27f2dd109a303c4ca62813c7b3bb2511edb4777de/gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0", size = 225076, upload-time = "2026-07-22T04:08:51.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b9/876f442a28df5c068ca69b0122d5c35e65fd2d2fa9992ea5cb5944ea00a6/gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf", size = 216575, upload-time = "2026-07-22T04:08:50.05Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]
@@ -747,8 +747,8 @@ version = "9.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.11' and python_full_version < '3.15' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.15' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.11' and python_full_version < '3.15' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [


### PR DESCRIPTION
Closes all nine open Dependabot alerts on the repo. There were no code-scanning alerts.

`uv.lock` pinned GitPython **3.1.54**; every open advisory is fixed by **3.1.58** or earlier, so this moves the pin to **3.1.59** (current latest).

| Alert | Severity | GHSA | Patched in |
|---|---|---|---|
| #72 | high | `GHSA-hmq2-w58f-27jc` — arbitrary repo creation via unvalidated `.gitmodules` name | 3.1.58 |
| #71 | high | `GHSA-jm78-9fvv-mhgr` — git-config OPTION-name injection, forged `core.sshCommand` (RCE) | 3.1.58 |
| #70 | high | `GHSA-wvpp-8hx9-p66j` — short-option token smuggling past the option guard | 3.1.58 |
| #68 | high | `GHSA-9rj7-rf2p-w77r` — `Repo.init` `--template` clone hooks | 3.1.58 |
| #67 | high | `GHSA-4gmw-gg2m-w46p` — `read-tree` option forwarding, arbitrary file overwrite | 3.1.58 |
| #64 | high | `GHSA-3f7w-8rr8-f37f` — `IndexFile.checkout()` / `TagReference.create()` | 3.1.57 |
| #69 | medium | `GHSA-hh9p-6wh2-4mfc` — `--pathspec-from-file` arbitrary file read | 3.1.58 |
| #66 | medium | `GHSA-p538-c434-8v24` — `rev-list --output` file truncation | 3.1.56 |
| #65 | medium | `GHSA-539m-9xh6-q6rr` — `Repo.archive()` `--add-file` denylist gap | 3.1.57 |

## Why a lockfile-only change

GitPython is not a direct dependency. It arrives transitively through `mknotebooks 0.8.0`, which requires it unpinned, so bumping the lock is sufficient — no `pyproject.toml` change needed. Nothing in this repo imports `git` directly.

## Notes

Locked with **uv 0.12.5**. Locking with an older uv rewrote marker metadata across ~28 unrelated entries; using current uv keeps the diff confined to the GitPython entry plus two cosmetic `resolution-markers` reorderings.

## Verification

- `uv lock --check` → passes, 137 packages resolved
- `mkdocs build` in a clean Python 3.10 env with GitPython 3.1.59 → exit 0

That second check is the one that matters: `mknotebooks` is the only consumer, and these advisories are fixed by *tightening* git option validation, so a caller passing a now-rejected option is the plausible regression. The docs build is where it would surface, and it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvT2bzCPzJsK3wVa5BTBT