### PR TITLE
fix(ci): unblock Dependabot uv updates and close CI coverage gaps

### DIFF
--- a/.github/workflows/ci-scripts-docs.yml
+++ b/.github/workflows/ci-scripts-docs.yml
@@ -10,12 +10,16 @@ on:
       - 'src/scripts/**'
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches: [main]
     paths:
       - 'src/scripts/**'
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   docs:

--- a/.github/workflows/ci-scripts-test.yml
+++ b/.github/workflows/ci-scripts-test.yml
@@ -8,10 +8,14 @@ on:
     branches: [main]
     paths:
       - 'src/scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches: [main]
     paths:
       - 'src/scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   test:

--- a/.github/workflows/ci-ts-test.yml
+++ b/.github/workflows/ci-ts-test.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
     paths:
       - 'packages/ts-*/**'
+      - 'packages/playground/**'
+      - 'package.json'
       - 'src/scripts/code_gen/templates_ts/**'
       - 'src/scripts/code_gen/gen.py'
       - 'src/scripts/code_gen/cli.py'
@@ -16,6 +18,8 @@ on:
     branches: [main]
     paths:
       - 'packages/ts-*/**'
+      - 'packages/playground/**'
+      - 'package.json'
       - 'src/scripts/code_gen/templates_ts/**'
       - 'src/scripts/code_gen/gen.py'
       - 'src/scripts/code_gen/cli.py'

--- a/.github/workflows/regen-bindings.yml
+++ b/.github/workflows/regen-bindings.yml
@@ -166,8 +166,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add -f packages/v5/src/ffmpeg/ packages/v6/src/ffmpeg/ packages/v7/src/ffmpeg/ packages/v8/src/ffmpeg/
-          git add -f packages/core/src/ffmpeg_core/common/cache/list/
+          git add packages/v5/src/ffmpeg/ packages/v6/src/ffmpeg/ packages/v7/src/ffmpeg/ packages/v8/src/ffmpeg/
+          git add packages/core/src/ffmpeg_core/common/cache/list/
           git commit -m "chore: regenerate bindings for FFmpeg v5/v6/v7/v8"
           git push origin "$BRANCH"
           gh pr create \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,13 @@ graph = ["graphviz"]
 
 [tool.uv]
 sources = { ffmpeg-core = { workspace = true }, ffmpeg-data-v5 = { workspace = true }, ffmpeg-data-v6 = { workspace = true }, ffmpeg-data-v7 = { workspace = true }, ffmpeg-data-v8 = { workspace = true } }
-dev-dependencies = [
+
+# PEP 735 dependency group. Must NOT be moved back to the legacy
+# `[tool.uv] dev-dependencies`: uv merges both into the same `dev` group, and
+# Dependabot writes bumps here, so having both makes the group contradict
+# itself (`ruff==0.16.2` and `ruff==0.12.2`) and every uv update job fails.
+[dependency-groups]
+dev = [
     # Development tools
     "ty",
     "devtools",


### PR DESCRIPTION
The `uv in /.` Dependabot job has failed on **every run since 2026-08-13**. That's why nine GitPython advisories piled up instead of arriving as individual bumps — `ruff` and `pytest-cov` both errored with `dependency_file_not_resolvable`.

## Root cause

The root manifest declared its dev dependencies in the deprecated **`[tool.uv] dev-dependencies`**. Dependabot doesn't write there — it writes bumps into PEP 735 **`[dependency-groups] dev`**. uv merges *both* into the same `dev` group, so after Dependabot's edit the group held `ruff==0.16.2` and `ruff==0.12.2` simultaneously and became unsatisfiable.

Confirmed by appending a `[dependency-groups] dev = ["ruff==0.16.2"]` block to the unmodified manifest, which reproduces Dependabot's error almost verbatim:

```
Dependabot: Because typed-ffmpeg-workspace:dev depends on ruff==0.16.2 and ruff==0.12.2,
            we can conclude that typed-ffmpeg-workspace:dev cannot be used.

local sim:  Because typed-ffmpeg-workspace:dev depends on ruff==0.12.2 and ruff==0.16.2,
            we can conclude that typed-ffmpeg-workspace:dev cannot be used.
```

Only the operand order differs. Migrating the root to `[dependency-groups] dev` leaves exactly one declaration for Dependabot to edit in place — and drops uv's deprecation warning as a side effect.

**Post-fix simulation:** bumping ruff 0.12.2 → 0.16.2 across the root *and* all six member manifests, plus raising the `pytest-cov` cap, now resolves cleanly (`Resolved 137 packages`, `Updated ruff v0.12.2 -> v0.16.2`). Before the fix, the same bump failed.

## Coverage gaps, same theme

Both of today's merges landed without any suite exercising them. That's not a coincidence — it's two path filters that are too narrow:

| Workflow | Watched | Missed |
|---|---|---|
| `ci-scripts-test` / `ci-scripts-docs` | `src/scripts/**` | the GitPython lock bump in bbab81fe ran **no** suite |
| `ci-ts-test` | `packages/ts-*/**` | the playground TypeScript bump that broke the shared workspace install never triggered it |

Now watching `pyproject.toml` + `uv.lock`, and `packages/playground/**` + root `package.json` respectively.

## Also

Dropped the `git add -f` in `regen-bindings.yml`. It worked around the over-broad `ffmpeg/` ignore rule fixed in 4ecc1d78, and `-f` would force-add genuinely ignored files like `__pycache__`.

## Verification

- `uv lock` → **no change to `uv.lock`**, no deprecation warning (migration is resolution-neutral)
- `uv lock --check` → passes, 137 packages
- `uv sync --group dev` → exit 0 (used by `ci-scripts-test`)
- `uv pip install --group dev` → exit 0 (used by `ci-scripts-docs`)
- `pytest src/scripts` in the synced env → **136 passed, 40 skipped**

The migration being resolution-neutral is the key check: it proves this changes *where* the dev deps are declared, not *what* resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvT2bzCPzJsK3wVa5BTBT