### PR TITLE
feat(docker): FFmpeg 9.0 build image, plus two codegen reliability fixes

### DIFF
--- a/.github/workflows/build-ffmpeg-images.yml
+++ b/.github/workflows/build-ffmpeg-images.yml
@@ -30,14 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg-version: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ffmpeg-version != 'all') && fromJSON(format('["{0}"]', github.event.inputs.ffmpeg-version)) || fromJSON('["7.1", "8.0", "9.0"]') }}
-        include:
-          - ffmpeg-version: '7.1'
-            ffmpeg-source-version: '7.1.1'
-          - ffmpeg-version: '8.0'
-            ffmpeg-source-version: '8.0'
-          # 9.0.x latest patch built as tag 9.0, as 7.1 builds 7.1.1.
-          - ffmpeg-version: '9.0'
-            ffmpeg-source-version: '9.0.1'
 
     steps:
       - uses: actions/checkout@v7
@@ -52,6 +44,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # The source version was carried in `matrix.include`, but an include entry
+      # whose key does not match the active combination is appended as an extra
+      # job rather than merged — so dispatching one version still built all of
+      # them. Resolving it here keeps the matrix to exactly what was asked for.
+      - name: Resolve FFmpeg source version
+        id: src
+        run: |
+          case "${{ matrix.ffmpeg-version }}" in
+            7.1) v=7.1.1 ;;
+            8.0) v=8.0   ;;
+            9.0) v=9.0.1 ;;
+            *)   echo "::error::No source version mapped for ${{ matrix.ffmpeg-version }}"; exit 1 ;;
+          esac
+          echo "Building FFmpeg $v as tag ${{ matrix.ffmpeg-version }}"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
       - name: Build and push FFmpeg ${{ matrix.ffmpeg-version }}
         uses: docker/build-push-action@v7
         with:
@@ -60,7 +68,7 @@ jobs:
           push: true
           platforms: linux/amd64
           build-args: |
-            FFMPEG_SOURCE_VERSION=${{ matrix.ffmpeg-source-version }}
+            FFMPEG_SOURCE_VERSION=${{ steps.src.outputs.version }}
           tags: |
             ghcr.io/${{ github.repository }}/ffmpeg:${{ matrix.ffmpeg-version }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/ffmpeg:${{ matrix.ffmpeg-version }}-cache

--- a/.github/workflows/build-ffmpeg-images.yml
+++ b/.github/workflows/build-ffmpeg-images.yml
@@ -16,6 +16,7 @@ on:
         options:
           - '7.1'
           - '8.0'
+          - '9.0'
           - 'all'
 
 permissions:
@@ -28,12 +29,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ffmpeg-version: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ffmpeg-version != 'all') && fromJSON(format('["{0}"]', github.event.inputs.ffmpeg-version)) || fromJSON('["7.1", "8.0"]') }}
+        ffmpeg-version: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ffmpeg-version != 'all') && fromJSON(format('["{0}"]', github.event.inputs.ffmpeg-version)) || fromJSON('["7.1", "8.0", "9.0"]') }}
         include:
           - ffmpeg-version: '7.1'
             ffmpeg-source-version: '7.1.1'
           - ffmpeg-version: '8.0'
             ffmpeg-source-version: '8.0'
+          # 9.0.x latest patch built as tag 9.0, as 7.1 builds 7.1.1.
+          - ffmpeg-version: '9.0'
+            ffmpeg-source-version: '9.0.1'
 
     steps:
       - uses: actions/checkout@v7

--- a/docker/ffmpeg-builder/Dockerfile.9.0
+++ b/docker/ffmpeg-builder/Dockerfile.9.0
@@ -36,6 +36,11 @@ RUN apt-get update && apt-get install -y \
     libva-dev libdrm-dev ocl-icd-opencl-dev opencl-headers \
     # Vulkan (headers will be upgraded below to meet FFmpeg 9.0's >= 1.3.277 requirement)
     libvulkan-dev glslang-dev libshaderc-dev spirv-tools \
+    # FFmpeg 9.0 dropped --enable-libshaderc/--enable-libglslang and instead
+    # probes for a shader compiler *binary* (glslc / glslang / glslangValidator),
+    # so the tools package is required, not just the libs. spirv-headers backs
+    # the swscale SPIR-V path, which configure only warns about if missing.
+    glslang-tools spirv-headers \
     # Frei0r plugin framework
     frei0r-plugins-dev \
     # Audio: LADSPA, LV2, BS2B, Rubberband, SOFA (sofalizer)
@@ -88,10 +93,11 @@ RUN EXTRA_FLAGS=""; \
     pkg-config --exists harfbuzz   && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libharfbuzz"; \
     # libplacebo intentionally skipped: FFmpeg 9.0 requires >= 7.351.0 and
     # Ubuntu 24.04 ships 6.x.
-    # Vulkan: verify the upgraded headers meet FFmpeg 9.0's >= 1.3.277 requirement
+    # Vulkan: verify the upgraded headers meet FFmpeg 9.0's >= 1.3.277 requirement.
+    # No --enable-libshaderc here: 9.0 removed that option and finds a shader
+    # compiler binary itself once vulkan is enabled.
     pkg-config --atleast-version=1.3.277 vulkan 2>/dev/null \
         && EXTRA_FLAGS="$EXTRA_FLAGS --enable-vulkan"; \
-    pkg-config --exists shaderc    && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libshaderc"; \
     pkg-config --exists ffnvcodec  && EXTRA_FLAGS="$EXTRA_FLAGS --enable-cuvid --enable-nvenc --enable-nvdec"; \
     # CUDA filters (scale_cuda, overlay_cuda, etc.) — requires nvcc from nvidia-cuda-toolkit
     command -v nvcc >/dev/null 2>&1 && EXTRA_FLAGS="$EXTRA_FLAGS --enable-cuda-nvcc"; \

--- a/docker/ffmpeg-builder/Dockerfile.9.0
+++ b/docker/ffmpeg-builder/Dockerfile.9.0
@@ -1,0 +1,206 @@
+# FFmpeg 9.0 — Ubuntu 24.04 build with full codec/plugin support.
+#
+# Version-specific notes:
+#   - libplacebo is NOT enabled: FFmpeg 9.0's configure requires
+#     libplacebo >= 7.351.0 and Ubuntu 24.04 ships 6.x. (For 7.1/8.0 the
+#     blocker was an API mismatch; here it is simply too old.)
+#   - Vulkan: FFmpeg 9.0 still requires headers >= 1.3.277, same as 8.0, so
+#     the v1.3.283 upgrade below is unchanged. Note configure also gates some
+#     optional Vulkan code on >= 1.3.317, which 1.3.283 does not satisfy —
+#     that matches the 8.0 image, so the two stay comparable.
+#   - Source is 9.0.1 (latest 9.0.x patch) built as image tag 9.0, following
+#     Dockerfile.7.1 which builds 7.1.1 as tag 7.1.
+#
+# Usage:
+#   docker build -f Dockerfile.9.0 \
+#     --build-arg FFMPEG_SOURCE_VERSION=9.0.1 \
+#     -t ffmpeg:9.0 .
+
+ARG FFMPEG_SOURCE_VERSION=9.0.1
+ARG UBUNTU_VERSION=24.04
+
+FROM ubuntu:${UBUNTU_VERSION} AS build
+
+ARG FFMPEG_SOURCE_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential nasm yasm pkg-config wget ca-certificates git \
+    libx264-dev libx265-dev libnuma-dev libvpx-dev libmp3lame-dev \
+    libopus-dev libvorbis-dev libtheora-dev libwebp-dev libxvidcore-dev \
+    libopenjp2-7-dev libopencore-amrnb-dev libopencore-amrwb-dev \
+    libass-dev libfreetype6-dev libfontconfig1-dev libfribidi-dev \
+    libzimg-dev libvidstab-dev libaom-dev \
+    libssl-dev libsrt-openssl-dev libzmq3-dev \
+    libva-dev libdrm-dev ocl-icd-opencl-dev opencl-headers \
+    # Vulkan (headers will be upgraded below to meet FFmpeg 9.0's >= 1.3.277 requirement)
+    libvulkan-dev glslang-dev libshaderc-dev spirv-tools \
+    # Frei0r plugin framework
+    frei0r-plugins-dev \
+    # Audio: LADSPA, LV2, BS2B, Rubberband, SOFA (sofalizer)
+    ladspa-sdk \
+    lv2-dev liblilv-dev \
+    libbs2b-dev \
+    librubberband-dev \
+    libmysofa-dev \
+    # Flite (text-to-speech)
+    flite1-dev \
+    # Additional codecs
+    libgsm1-dev libspeex-dev libtwolame-dev libshine-dev \
+    libcodec2-dev libsnappy-dev libbluray-dev libfdk-aac-dev \
+    libjxl-dev librsvg2-dev libzvbi-dev \
+    # CUDA toolkit (nvcc) for compiling CUDA filter kernels (scale_cuda, overlay_cuda, etc.)
+    nvidia-cuda-toolkit \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional packages that may not exist on all Ubuntu versions
+# Note: libplacebo-dev intentionally omitted — FFmpeg 9.0 needs >= 7.351.0, Ubuntu 24.04 has 6.x
+RUN apt-get update \
+    && apt-get install -y libdav1d-dev libsvtav1-dev libharfbuzz-dev librav1e-dev 2>/dev/null || true \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install nv-codec-headers (CUDA/NVENC support without a physical GPU)
+RUN git clone --depth 1 https://github.com/FFmpeg/nv-codec-headers.git /tmp/nv-codec-headers \
+    && cd /tmp/nv-codec-headers \
+    && make install PREFIX=/usr/local \
+    && rm -rf /tmp/nv-codec-headers
+
+# Upgrade Vulkan headers to >= 1.3.277 (FFmpeg 9.0 requirement, unchanged from 8.0).
+# Ubuntu 24.04 ships 1.3.275 — two patch versions too old.
+RUN if ! pkg-config --atleast-version=1.3.277 vulkan 2>/dev/null; then \
+      git clone --depth 1 --branch v1.3.283 https://github.com/KhronosGroup/Vulkan-Headers.git /tmp/vulkan-headers; \
+      cp -r /tmp/vulkan-headers/include/vulkan /usr/include/; \
+      cp -r /tmp/vulkan-headers/include/vk_video /usr/include/; \
+      find /usr /lib -name 'vulkan.pc' 2>/dev/null -exec sed -i 's/^Version:.*/Version: 1.3.283/' {} +; \
+      rm -rf /tmp/vulkan-headers; \
+    fi
+
+RUN wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_SOURCE_VERSION}.tar.bz2" \
+    && tar xf "ffmpeg-${FFMPEG_SOURCE_VERSION}.tar.bz2" \
+    && mv "ffmpeg-${FFMPEG_SOURCE_VERSION}" /ffmpeg-src
+
+WORKDIR /ffmpeg-src
+
+RUN EXTRA_FLAGS=""; \
+    pkg-config --exists dav1d      && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libdav1d"; \
+    pkg-config --exists SvtAv1Enc  && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libsvtav1"; \
+    pkg-config --exists harfbuzz   && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libharfbuzz"; \
+    # libplacebo intentionally skipped: FFmpeg 9.0 requires >= 7.351.0 and
+    # Ubuntu 24.04 ships 6.x.
+    # Vulkan: verify the upgraded headers meet FFmpeg 9.0's >= 1.3.277 requirement
+    pkg-config --atleast-version=1.3.277 vulkan 2>/dev/null \
+        && EXTRA_FLAGS="$EXTRA_FLAGS --enable-vulkan"; \
+    pkg-config --exists shaderc    && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libshaderc"; \
+    pkg-config --exists ffnvcodec  && EXTRA_FLAGS="$EXTRA_FLAGS --enable-cuvid --enable-nvenc --enable-nvdec"; \
+    # CUDA filters (scale_cuda, overlay_cuda, etc.) — requires nvcc from nvidia-cuda-toolkit
+    command -v nvcc >/dev/null 2>&1 && EXTRA_FLAGS="$EXTRA_FLAGS --enable-cuda-nvcc"; \
+    EXTRA_FLAGS="$EXTRA_FLAGS --enable-frei0r --enable-ladspa"; \
+    pkg-config --exists lilv-0     && EXTRA_FLAGS="$EXTRA_FLAGS --enable-lv2"; \
+    pkg-config --exists libbs2b    && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libbs2b"; \
+    pkg-config --exists rubberband && EXTRA_FLAGS="$EXTRA_FLAGS --enable-librubberband"; \
+    pkg-config --exists libmysofa  && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libmysofa"; \
+    test -f /usr/include/flite/flite.h && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libflite"; \
+    # Additional codecs
+    test -f /usr/include/gsm/gsm.h && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libgsm"; \
+    pkg-config --exists speex      && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libspeex"; \
+    pkg-config --exists twolame    && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libtwolame"; \
+    pkg-config --exists shine      && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libshine"; \
+    pkg-config --exists codec2     && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libcodec2"; \
+    test -f /usr/include/snappy-c.h && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libsnappy"; \
+    pkg-config --exists libbluray  && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libbluray"; \
+    pkg-config --exists fdk-aac    && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libfdk-aac"; \
+    pkg-config --exists rav1e      && EXTRA_FLAGS="$EXTRA_FLAGS --enable-librav1e"; \
+    pkg-config --exists libjxl     && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libjxl"; \
+    pkg-config --exists librsvg-2.0 && EXTRA_FLAGS="$EXTRA_FLAGS --enable-librsvg"; \
+    pkg-config --exists zvbi       && EXTRA_FLAGS="$EXTRA_FLAGS --enable-libzvbi"; \
+    # postproc is not a separate configure option in FFmpeg 8.0+ (verified absent in 9.0's configure)
+
+    echo "Extra configure flags: $EXTRA_FLAGS"; \
+    ./configure \
+        --prefix=/usr/local \
+        --disable-debug \
+        --disable-doc \
+        --disable-ffplay \
+        --enable-gpl \
+        --enable-nonfree \
+        --enable-version3 \
+        --enable-shared \
+        --enable-libx264 \
+        --enable-libx265 \
+        --enable-libvpx \
+        --enable-libmp3lame \
+        --enable-libopus \
+        --enable-libvorbis \
+        --enable-libtheora \
+        --enable-libwebp \
+        --enable-libxvid \
+        --enable-libopenjpeg \
+        --enable-libopencore-amrnb \
+        --enable-libopencore-amrwb \
+        --enable-libass \
+        --enable-libfreetype \
+        --enable-fontconfig \
+        --enable-libfribidi \
+        --enable-libzimg \
+        --enable-libvidstab \
+        --enable-libaom \
+        --enable-openssl \
+        --enable-libsrt \
+        --enable-libzmq \
+        --enable-vaapi \
+        --enable-opencl \
+        $EXTRA_FLAGS \
+    || { echo "=== configure failed — ffbuild/config.log ==="; \
+         cat ffbuild/config.log 2>/dev/null || cat config.log 2>/dev/null; \
+         exit 1; } \
+    && make -j$(nproc) \
+    && make install
+
+# Runtime stage — install only runtime libs (not -dev), set LD_LIBRARY_PATH
+FROM ubuntu:${UBUNTU_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+
+# Required runtime libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libx264-164 libx265-199 libnuma1 libvpx9 libmp3lame0 \
+    libopus0 libvorbis0a libvorbisenc2 libtheora0 \
+    libwebp7 libwebpmux3 libwebpdemux2 libsharpyuv0 libxvidcore4 \
+    libopenjp2-7 libopencore-amrnb0 libopencore-amrwb0 \
+    libass9 libfreetype6 libfontconfig1 libfribidi0 fonts-dejavu-core \
+    libzimg2 libvidstab1.1 libaom3 \
+    libssl3t64 libsrt1.5-openssl libzmq5 \
+    libxml2 libbluray2 libfdk-aac2 \
+    libva2 libva-drm2 libdrm2 ocl-icd-libopencl1 libvdpau1 \
+    libvulkan1 libxcb1 libxcb-shm0 libxcb-xfixes0 \
+    libbs2b0 librubberband2 libmysofa1 liblilv-0-0 \
+    frei0r-plugins \
+    libgsm1 libspeex1 libtwolame0 libshine3 \
+    libsnappy1v5 \
+    libzvbi0 librsvg2-2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional runtime libs — install each separately so one failure doesn't block others
+RUN apt-get update \
+    && for pkg in libdav1d7 libsvtav1enc1d1 libharfbuzz0b \
+                  libshaderc1 libflite1 librav1e0 \
+                  libjxl0.10 libjxl0.7 \
+                  libcodec2-1.2 libcodec2-1.0; do \
+         apt-get install -y --no-install-recommends "$pkg" 2>/dev/null || true; \
+       done \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local/bin/ffmpeg  /usr/local/bin/ffmpeg
+COPY --from=build /usr/local/bin/ffprobe /usr/local/bin/ffprobe
+COPY --from=build /usr/local/lib         /usr/local/lib
+RUN ldconfig
+
+# Validate: ffmpeg must start and muxer descriptions must not be empty
+RUN ffmpeg -version 2>&1 | head -3 \
+    && ffmpeg -muxers 2>&1 | grep "3g2" \
+    || { echo "ERROR: ffmpeg validation failed"; ffmpeg -version 2>&1; exit 1; }
+
+ENTRYPOINT ["/usr/local/bin/ffmpeg"]

--- a/src/scripts/net.py
+++ b/src/scripts/net.py
@@ -1,0 +1,72 @@
+"""
+Network helpers for codegen.
+
+Codegen fetches the FFmpeg filter docs and release archives at generation
+time, so a transient reset fails the whole run — and because the create-PR
+step needs every matrix leg, one flaky version blocks the pipeline. Observed
+on main: `ConnectionResetError: [Errno 104] Connection reset by peer` in
+generate (8) while v5/v6/v7 succeeded.
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.error
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """
+    Decide whether an exception is worth retrying.
+
+    Args:
+        exc: The exception raised by the operation.
+
+    Returns:
+        True if retrying could plausibly succeed.
+
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        # 4xx is a bad request; it will fail identically next time.
+        return exc.code >= 500
+    # URLError, ConnectionResetError and TimeoutError are all OSError.
+    return isinstance(exc, OSError)
+
+
+def with_retry(
+    operation: Callable[[], T],
+    *,
+    attempts: int = 4,
+    base_delay: float = 1.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> T:
+    """
+    Run an operation, retrying transient network failures with backoff.
+
+    Args:
+        operation: Zero-argument callable performing the request.
+        attempts: Total tries, including the first.
+        base_delay: Seconds before the first retry; doubles each time.
+        sleep: Injected for tests.
+
+    Returns:
+        Whatever the operation returns.
+
+    Raises:
+        Exception: The final failure, once attempts are exhausted or the
+            error is not retryable.
+
+    """
+    # The last attempt is deliberately outside the loop so its exception
+    # propagates naturally — no unreachable fall-through to appease a checker.
+    for attempt in range(1, attempts):
+        try:
+            return operation()
+        except Exception as exc:
+            if not _is_retryable(exc):
+                raise
+            sleep(base_delay * 2 ** (attempt - 1))
+    return operation()

--- a/src/scripts/parse_c/pre_compile.py
+++ b/src/scripts/parse_c/pre_compile.py
@@ -17,6 +17,7 @@ import urllib.request
 
 from ffmpeg_core.common.cache import get_cache_path
 
+from ..net import with_retry
 from ..parse_help.utils import get_ffmpeg_version
 
 DEFAULT_FFMPEG_RELEASE_BASE_URL = "https://ffmpeg.org/releases"
@@ -35,7 +36,9 @@ def _download_release_archive(version: str) -> pathlib.Path:
     archive_path = cache_root / f"ffmpeg-{version}.tar.xz"
     if archive_path.exists():
         return archive_path
-    urllib.request.urlretrieve(_release_archive_url(version), archive_path)
+    with_retry(
+        lambda: urllib.request.urlretrieve(_release_archive_url(version), archive_path)
+    )
     return archive_path
 
 

--- a/src/scripts/parse_docs/cli.py
+++ b/src/scripts/parse_docs/cli.py
@@ -9,6 +9,7 @@ import typer
 
 from ffmpeg_core.common.cache import cache_path, save
 
+from ..net import with_retry
 from .helpers import parse_filter_document
 from .parse_texi import parse_texi_sections
 from .schema import FilterDocument
@@ -37,8 +38,8 @@ def download_ffmpeg_filter_documents() -> Path:
 
     typer.echo("Downloading filter documents...")
     url = "https://ffmpeg.org/ffmpeg-filters.html"
-    response = urllib.request.urlopen(url)
-    data = response.read()
+    # ffmpeg.org resets connections often enough to fail a whole codegen run.
+    data = with_retry(lambda: urllib.request.urlopen(url).read())
     text = data.decode("utf-8")
 
     with filter_path.open("w") as ofile:

--- a/src/scripts/tests/test_net.py
+++ b/src/scripts/tests/test_net.py
@@ -1,0 +1,85 @@
+"""Tests for the codegen network retry helper."""
+
+import urllib.error
+
+import pytest
+
+from scripts.net import with_retry
+
+
+def test_retries_transient_error_then_succeeds() -> None:
+    """A connection reset should be retried, not fatal."""
+    attempts = 0
+
+    def flaky() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ConnectionResetError(104, "Connection reset by peer")
+        return "downloaded"
+
+    slept: list[float] = []
+    result = with_retry(flaky, sleep=slept.append)
+
+    assert result == "downloaded"
+    assert attempts == 3
+    assert len(slept) == 2
+
+
+def test_raises_after_exhausting_attempts() -> None:
+    """Give up eventually rather than looping forever."""
+    attempts = 0
+
+    def always_fails() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise ConnectionResetError(104, "Connection reset by peer")
+
+    with pytest.raises(ConnectionResetError):
+        with_retry(always_fails, attempts=3, sleep=lambda _: None)
+
+    assert attempts == 3
+
+
+def test_does_not_retry_client_errors() -> None:
+    """A 404 will not fix itself, so retrying only wastes a CI minute."""
+    attempts = 0
+
+    def not_found() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise urllib.error.HTTPError("http://x", 404, "Not Found", {}, None)  # type: ignore[arg-type]
+
+    with pytest.raises(urllib.error.HTTPError):
+        with_retry(not_found, sleep=lambda _: None)
+
+    assert attempts == 1
+
+
+def test_retries_server_errors() -> None:
+    """A 503 is transient, so it should be retried."""
+    attempts = 0
+
+    def flaky_server() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise urllib.error.HTTPError("http://x", 503, "Unavailable", {}, None)  # type: ignore[arg-type]
+        return "ok"
+
+    assert with_retry(flaky_server, sleep=lambda _: None) == "ok"
+    assert attempts == 2
+
+
+def test_backoff_grows_between_attempts() -> None:
+    """Successive waits should increase, so a slow blip is not hammered."""
+
+    def always_fails() -> str:
+        raise ConnectionResetError(104, "Connection reset by peer")
+
+    slept: list[float] = []
+    with pytest.raises(ConnectionResetError):
+        with_retry(always_fails, attempts=4, base_delay=1.0, sleep=slept.append)
+
+    assert slept == sorted(slept)
+    assert slept[0] < slept[-1]


### PR DESCRIPTION
Step A of FFmpeg 9 support, plus two fixes the work exposed that stand on their own.

## 1. FFmpeg 9.0 build image

There is no off-the-shelf 9.x image — `jrottenberg/ffmpeg` tops out at 8.0 — so the binary codegen introspects has to be built here, as was already done for 7.1 and 8.0.

`Dockerfile.9.0` is ported from `Dockerfile.8.0`. Version-specific differences:

- **libplacebo stays disabled, for a different reason.** 8.0 blocked on an API mismatch with Ubuntu 24.04's 6.x; 9.0's configure requires `>= 7.351.0`, so 6.x is simply too old.
- **Vulkan is unchanged.** 9.0 still gates on headers `>= 1.3.277`, so the existing v1.3.283 upgrade suffices. configure also has an optional path behind `>= 1.3.317` that 1.3.283 does not satisfy — the same is true of the 8.0 image, so the two stay comparable.
- **Source is 9.0.1**, the latest 9.0.x patch, built as image tag `9.0` — following `Dockerfile.7.1`, which builds 7.1.1 as tag 7.1.

### `--enable-libshaderc` had to go, and I only found that by building

My initial static check claimed all 60 configure flags survive into 9.0. **That was wrong** — it grepped the flag name anywhere in `configure`, which matches unrelated occurrences. The first build failed with:

```
Unknown option "--enable-libshaderc".
```

Re-checked properly (a flag must appear as an `--enable-`/`--disable-` help entry or as a component-list entry) and `libshaderc` is the only one of the 60 that 9.0 removed.

FFmpeg 9.0 dropped both `--enable-libshaderc` and `--enable-libglslang`. Once vulkan is enabled, configure instead probes for a shader compiler **binary** (`glslc` / `glslang` / `glslangValidator`) and separately looks for `spirv-headers` to back the swscale SPIR-V path. So the flag is removed and `glslang-tools` + `spirv-headers` are added — package names and the binaries they provide were verified in an `ubuntu:24.04` container.

### Verified against the published image, not the log

```
ffmpeg version 9.0.1        ffprobe version 9.0.1
filters: 553                (regenerated 8.0 data has 549)
hardware filters: 62        (vaapi / opencl / vulkan / cuda)
premultiply_dynamic: present
```

That last line closes a loop from #1005: `premultiply_dynamic` was identified there as an **8.1-only** filter, which is how the old `data-v8` was proven to contain 8.1 data. It appearing in the 9.0 image confirms the version mapping end to end.

## 2. Dispatch filter was building every version

Dispatching a single version built all of them. The source version was carried in `matrix.include`, but an include entry whose key does not match the active combination is **appended as an extra job** rather than merged — so `["9.0"]` plus includes for 7.1 and 8.0 produced three jobs. Resolving the version in a step instead keeps the matrix to exactly what was requested. Confirmed: the re-dispatch ran only `build (9.0)`.

## 3. Codegen now retries transient network failures

Separate cause from the 100/100 workflow failure fixed in #1005, same symptom of "binding generation often fails".

Codegen fetches the FFmpeg docs and release archives at generation time and neither call retried. On `main` this cost a whole run — `generate (8)` died with `ConnectionResetError: [Errno 104] Connection reset by peer` while v5/v6/v7 succeeded, and because the apply step needs every matrix leg, it was skipped entirely.

`scripts.net.with_retry` adds exponential backoff over the OSError family (URLError, ConnectionResetError, TimeoutError), retrying HTTP 5xx but **not** 4xx — a 404 will fail identically next time. Written test-first; suite goes 136 → 141.

**Known gap left alone:** `_download_release_archive` short-circuits on `archive_path.exists()`, so a process killed mid-download leaves a partial archive that later runs treat as complete. Pre-existing and unrelated to retrying, but worth a follow-up.

## Not in this PR

Packages (`v9`, `data-v9`, `ts-v9`), the codegen matrix entry, test matrices and the `latest` re-point. Those come next, now that the image is confirmed good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvT2bzCPzJsK3wVa5BTBT