### PR TITLE
chore: sync the ruff pre-commit pin with pyproject

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,10 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "@typed-ffmpeg/*"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/" # Typically GitHub Actions workflows are located in .github/workflows
     schedule:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,11 @@ repos:
         exclude: '__snapshots__/|.eslintrc.json|tsconfig.*\.json'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version - keep in sync with pyproject.toml and uv.lock
-    rev: v0.12.2
+    # Ruff version - keep in sync with pyproject.toml and uv.lock.
+    # Dependabot's `pre-commit` ecosystem (see .github/dependabot.yml) bumps
+    # this; before it was configured, uv bumped pyproject and this pin silently
+    # drifted, so formatting ran on a different ruff than the project declared.
+    rev: v0.16.2
     hooks:
       # Run the formatter (includes generated bindings).
       - id: ruff-format

--- a/packages/core/src/ffmpeg_core/__init__.py
+++ b/packages/core/src/ffmpeg_core/__init__.py
@@ -19,8 +19,8 @@ __version__ = "1.0.0"
 from .exceptions import FFMpegExecuteError, FFMpegTypeError, FFMpegValueError
 
 __all__ = [
-    "__version__",
     "FFMpegExecuteError",
     "FFMpegTypeError",
     "FFMpegValueError",
+    "__version__",
 ]

--- a/packages/core/src/ffmpeg_core/common/serialize.py
+++ b/packages/core/src/ffmpeg_core/common/serialize.py
@@ -24,8 +24,8 @@ A registry of classes that have been loaded, and can be deserialized.
 
 
 def serializable(
-    cls: type[Serializable] | type[Enum],
-) -> type[Serializable] | type[Enum]:
+    cls: type[Serializable | Enum],
+) -> type[Serializable | Enum]:
     """
     Register a class with the serialization system.
 
@@ -53,7 +53,7 @@ class Serializable:
         serializable(cls)
 
 
-def load_class(name: str) -> type[Serializable] | type[Enum]:
+def load_class(name: str) -> type[Serializable | Enum]:
     """
     Load a class from its name.
 
@@ -143,15 +143,14 @@ def object_hook(obj: Any) -> Any:
         ```
 
     """
-    if isinstance(obj, dict):
-        if obj.get("__class__"):
-            cls = load_class(obj.pop("__class__"))
+    if isinstance(obj, dict) and obj.get("__class__"):
+        cls = load_class(obj.pop("__class__"))
 
-            if is_dataclass(cls):
-                # NOTE: in our application, the dataclass is always frozen
-                return cls(**{k: frozen(v) for k, v in obj.items()})
+        if is_dataclass(cls):
+            # NOTE: in our application, the dataclass is always frozen
+            return cls(**{k: frozen(v) for k, v in obj.items()})
 
-            return cls(**dict(obj.items()))
+        return cls(**dict(obj.items()))
 
     return obj
 

--- a/packages/core/src/ffmpeg_core/exceptions.py
+++ b/packages/core/src/ffmpeg_core/exceptions.py
@@ -15,8 +15,6 @@ class FFMpegError(Exception):
     typed-ffmpeg library. It inherits from the standard Python Exception class.
     """
 
-    ...
-
 
 class FFMpegTypeError(FFMpegError, TypeError):
     """

--- a/packages/core/src/ffmpeg_core/expressions.py
+++ b/packages/core/src/ffmpeg_core/expressions.py
@@ -624,7 +624,7 @@ def pow(x: Any, y: Any) -> Expression:
     return Expression(f"pow({x},{y})")
 
 
-def print(t: Any, l: Any | None = None) -> Expression:  # noqa: E741
+def print(t: Any, l: Any | None = None) -> Expression:
     """
     Print the value of expression t with loglevel l. If l is not specified then a default log level is used. Return the value of the expression printed.
 

--- a/packages/core/src/ffmpeg_core/ffprobe/tests/test_probe.py
+++ b/packages/core/src/ffmpeg_core/ffprobe/tests/test_probe.py
@@ -66,13 +66,14 @@ def test_probe_default(path: Path, snapshot: SnapshotAssertion) -> None:
         if stream["codec_type"] != "data":
             assert "codec_name" in stream
 
-    snapshot(
-        name="json", extension_class=JSONSnapshotExtension
-    ) == info  # NOTE: the result is not stable so, we just want to record the result
+    # Result is deliberately discarded: ffprobe output is not stable across
+    # versions, so the snapshot is recorded rather than asserted. Binding it
+    # keeps that intent in the code rather than only in a comment (B015).
+    _ = snapshot(name="json", extension_class=JSONSnapshotExtension) == info
 
     obj = probe_obj(path)
     assert obj is not None
-    snapshot(name="obj", extension_class=JSONSnapshotExtension) == asdict(obj)
+    _ = snapshot(name="obj", extension_class=JSONSnapshotExtension) == asdict(obj)
 
 
 @requires_ffprobe
@@ -134,9 +135,10 @@ def test_probe_complete(path: Path, snapshot: SnapshotAssertion) -> None:
                 assert "sample_rate" in stream
                 assert "channels" in stream
 
-    snapshot(
-        name="json", extension_class=JSONSnapshotExtension
-    ) == info  # NOTE: the result is not stable so, we just want to record the result
+    # Result is deliberately discarded: ffprobe output is not stable across
+    # versions, so the snapshot is recorded rather than asserted. Binding it
+    # keeps that intent in the code rather than only in a comment (B015).
+    _ = snapshot(name="json", extension_class=JSONSnapshotExtension) == info
 
     obj = probe_obj(
         path,
@@ -152,7 +154,7 @@ def test_probe_complete(path: Path, snapshot: SnapshotAssertion) -> None:
         show_error=True,
     )
     assert obj is not None
-    snapshot(name="obj", extension_class=JSONSnapshotExtension) == asdict(obj)
+    _ = snapshot(name="obj", extension_class=JSONSnapshotExtension) == asdict(obj)
 
 
 @requires_ffprobe

--- a/packages/core/src/ffmpeg_core/schema.py
+++ b/packages/core/src/ffmpeg_core/schema.py
@@ -29,8 +29,6 @@ class Default(str):
 
     """
 
-    ...
-
 
 class Auto(Default):
     """
@@ -84,6 +82,6 @@ class FFMpegOptionGroup(dict[str, Any]):
 __all__ = [
     "Auto",
     "Default",
-    "StreamType",
     "FFMpegOptionGroup",
+    "StreamType",
 ]

--- a/packages/core/src/ffmpeg_core/utils/escaping.py
+++ b/packages/core/src/ffmpeg_core/utils/escaping.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from typing import Any
 
 
-def escape(text: str | int | float, chars: str = "\\'=:") -> str:
+def escape(text: str | float, chars: str = "\\'=:") -> str:
     r"""
     Escape special characters in a string for use in FFmpeg commands.
 

--- a/packages/core/src/ffmpeg_core/utils/frozendict.py
+++ b/packages/core/src/ffmpeg_core/utils/frozendict.py
@@ -80,7 +80,7 @@ class FrozenDict(Mapping[K, V], Generic[K, V]):
         """
         return f"FrozenDict({self._data})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """
         Compare this FrozenDict with another object for equality.
 

--- a/packages/core/src/ffmpeg_core/utils/lazy_eval/schema.py
+++ b/packages/core/src/ffmpeg_core/utils/lazy_eval/schema.py
@@ -292,7 +292,9 @@ class LazyValue(ABC):
         """
         v = self.partial(**values)
         if isinstance(v, LazyValue):
-            raise ValueError(v.keys())
+            # Not a type error: the value is well-typed but still missing
+            # bindings, and ValueError is the documented contract above.
+            raise ValueError(v.keys())  # noqa: TRY004
         return v
 
     @abstractmethod

--- a/packages/tests-shared/compile/cases.py
+++ b/packages/tests-shared/compile/cases.py
@@ -100,7 +100,8 @@ def global_args() -> Stream:
 def global_args_2() -> Stream:
     input1 = input("input1.mp4")
     graph = (
-        input1.video.output(filename="tmp.mp4")
+        input1.video
+        .output(filename="tmp.mp4")
         .global_args(loglevel="info")
         .global_args(loglevel="warning")
     )

--- a/packages/tests-shared/utils/test_view.py
+++ b/packages/tests-shared/utils/test_view.py
@@ -67,7 +67,8 @@ def test_view_with_filter_chain() -> None:
         import graphviz  # type: ignore # noqa: F401
 
         output = (
-            ffmpeg.input("input.mp4")
+            ffmpeg
+            .input("input.mp4")
             .video.scale(w=1280, h=720)
             .fps(fps=30)
             .output(filename="output.mp4")

--- a/src/scripts/code_gen/schema.py
+++ b/src/scripts/code_gen/schema.py
@@ -113,7 +113,7 @@ class FFMpegAVOption(Serializable):
     @property
     def code_gen_type(self) -> str:
         """
-        Get the code generation type for this option.
+        The code generation type for this option.
 
         Returns:
             The type string for code generation.
@@ -218,7 +218,7 @@ class FFMpegCodec(Serializable):
     @property
     def codec_type(self) -> Literal["video", "audio", "subtitle"]:
         """
-        Get the type of this codec.
+        The type of this codec.
 
         Returns:
             The codec type.

--- a/src/scripts/parse_help/schema.py
+++ b/src/scripts/parse_help/schema.py
@@ -147,7 +147,7 @@ class FFMpegAVOption(FFMpegOption):
     @property
     def code_gen_type(self) -> str:
         """
-        Get the code generation type for this option.
+        The code generation type for this option.
 
         Returns:
             The type string for code generation.


### PR DESCRIPTION
`.pre-commit-config.yaml` pinned ruff **v0.12.2** while every pyproject declared **ruff==0.16.2** — despite the comment directly above the pin saying to keep them in sync.

Dependabot's uv job bumped the manifests once #1004 unblocked it, but nothing bumps a pre-commit `rev`. So formatting ran on a different ruff than the project declared. That is the same class of drift that produced a 40,000-line formatting diff in #1005, arriving from a different direction.

**Adds the `pre-commit` ecosystem to dependabot**, so the pin is maintained rather than depending on someone reading a comment.

## What the bump surfaced

Bumping the pin exposed 21 findings from rules that did not exist in 0.12.2. Formatting itself was nearly a no-op — 2 files across the whole repo.

**13 autofixed**, all reviewed:

| fix | file |
|---|---|
| `__all__` sorted (RUF022) | `ffmpeg_core/__init__.py` |
| redundant `...` in a class body that already has a docstring | `exceptions.py` |
| `__eq__(self, other: object)` | `frozendict.py` |
| chained call split — inside existing parens, still valid | `tests-shared/compile/cases.py` |

**8 handled individually**, not blanket-suppressed:

- **B015 `useless-comparison` × 4** in `test_probe.py`. These are the deliberate non-asserting snapshot lines — ffprobe output is not stable across versions, so the snapshot is *recorded*, not compared. ruff is technically right that the comparison is discarded. Bound to `_` so the intent lives in the code rather than only in a comment.
- **D421 `property-docstring-starts-with-verb` × 3.** Reworded `"Get the X"` → `"The X"`; they are properties, so they describe rather than act.
- **TRY004 `type-check-without-type-error` × 1** in `lazy_eval/schema.py`. Suppressed with a stated reason: the value is well-typed but missing bindings, and `ValueError` is the documented contract in the docstring immediately above. Changing it to `TypeError` would break that contract to satisfy a linter.

## Verification

Behaviour is unchanged, not just "tests pass":

```
test_probe        39 passed, same 76/94 snapshot split as before the change
packages/core    133 passed
src/scripts      141 passed
prek --all-files  clean
```

The snapshot split matching exactly is the meaningful check — it confirms the `_ =` binding on those four lines preserved the record-don't-assert behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvT2bzCPzJsK3wVa5BTBT