### PR TITLE
fix: complete FFmpeg 9 support (runtime cache, scripts, CI, docs)

### DIFF
--- a/.github/workflows/ci-monorepo-lint.yml
+++ b/.github/workflows/ci-monorepo-lint.yml
@@ -43,7 +43,7 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           pip install -e packages/core
-          pip install -e packages/v8
+          pip install -e packages/v9
           python <<EOF
           import sys
           import warnings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,6 @@ repos:
       - id: end-of-file-fixer
         files: ^(src/|packages/)
         exclude: '__snapshots__/'
-      - id: fix-encoding-pragma
-        files: ^(src/|packages/)
-        args: [--remove]
       - id: mixed-line-ending
         files: ^(src/|packages/)
       - id: trailing-whitespace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,13 +356,13 @@ uv lock --upgrade-package <package-name>
 
 ### Releasing a New Version
 
-Maintainers only. The monorepo publishes **11 packages** to PyPI in dependency order:
+Maintainers only. The monorepo publishes **13 packages** to PyPI in dependency order:
 
 | Layer | Packages |
 |-------|----------|
 | Core | `ffmpeg-core` |
-| Data | `ffmpeg-data-v5`, `ffmpeg-data-v6`, `ffmpeg-data-v7`, `ffmpeg-data-v8` |
-| Bindings | `typed-ffmpeg-v5`, `typed-ffmpeg-v6`, `typed-ffmpeg-v7`, `typed-ffmpeg-v8` |
+| Data | `ffmpeg-data-v5`, `ffmpeg-data-v6`, `ffmpeg-data-v7`, `ffmpeg-data-v8`, `ffmpeg-data-v9` |
+| Bindings | `typed-ffmpeg-v5`, `typed-ffmpeg-v6`, `typed-ffmpeg-v7`, `typed-ffmpeg-v8`, `typed-ffmpeg-v9` |
 | Meta | `typed-ffmpeg` (latest), `typed-ffmpeg-compatible` |
 
 #### Automated Release
@@ -376,7 +376,7 @@ python scripts/release.py --dry-run # preview without changes
 ```
 
 The script will:
-1. Bump version across all 11 packages (via `scripts/bump-version.py`)
+1. Bump version across all 13 packages (via `scripts/bump-version.py`)
 2. Insert a new CHANGELOG.md section and open your `$EDITOR`
 3. Commit and create a git tag
 4. Push to origin (with confirmation)
@@ -388,7 +388,7 @@ core → data → bindings → meta. Documentation is deployed automatically via
 #### Manual / Partial Publish
 
 You can also trigger the publish workflow manually from the Actions tab:
-- **`package`**: select specific packages (e.g. `core`, `v8`) or `all`
+- **`package`**: select specific packages (e.g. `core`, `v9`) or `all`
 - **`test-pypi`**: publish to TestPyPI first for validation (recommended for major releases)
 
 #### How Codegen Reaches main

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install typed-ffmpeg-v6      # install the matching package
 | `[graph]` | `pip install 'typed-ffmpeg[graph]'` | Graph visualization via Graphviz |
 | `[parse]` | `pip install 'typed-ffmpeg[parse]'` | CLI parsing and `compile_as_python()` support |
 
-The `[parse]` extra installs version-specific cache data (`ffmpeg-data-v5` through `ffmpeg-data-v8`) needed by `ffmpeg.compile.compile_cli.parse()` to reconstruct filter graphs from FFmpeg command lines. Most users do not need this.
+The `[parse]` extra installs version-specific cache data (`ffmpeg-data-v5` through `ffmpeg-data-v9`) needed by `ffmpeg.compile.compile_cli.parse()` to reconstruct filter graphs from FFmpeg command lines. Most users do not need this.
 
 See the [v4 Package Architecture](https://github.com/lucemia/typed-ffmpeg/blob/main/docs/v4-packages.md) docs for details and the [Migration Guide](https://github.com/lucemia/typed-ffmpeg/blob/main/docs/migration/v3-to-v4.md) if you are upgrading from typed-ffmpeg 3.x.
 
@@ -132,7 +132,7 @@ const cmd = input("input.mp4")
 // => ["-i", "input.mp4", "-filter_complex", "...", "output.mp4"]
 ```
 
-`@typed-ffmpeg/core` ships three builds — CJS (Node.js default), ESM, and a browser-safe ESM bundle — selected automatically via the `exports` field. The TypeScript API mirrors the Python API with idiomatic TypeScript patterns (options objects instead of keyword arguments). Each version package includes JSDoc annotations indicating filter availability across FFmpeg versions. See `packages/ts-core/` and `packages/ts-v5/` through `packages/ts-v8/` for details.
+`@typed-ffmpeg/core` ships three builds — CJS (Node.js default), ESM, and a browser-safe ESM bundle — selected automatically via the `exports` field. The TypeScript API mirrors the Python API with idiomatic TypeScript patterns (options objects instead of keyword arguments). Each version package includes JSDoc annotations indicating filter availability across FFmpeg versions. See `packages/ts-core/` and `packages/ts-v5/` through `packages/ts-v9/` for details.
 
 ---
 

--- a/docs/development/codegen.md
+++ b/docs/development/codegen.md
@@ -1,6 +1,6 @@
 # Code Generation
 
-Typed-ffmpeg generates its filter/codec/format bindings by introspecting real FFmpeg binaries. Each version package (`v5`, `v6`, `v7`, `v8`) is generated from the corresponding FFmpeg major version.
+Typed-ffmpeg generates its filter/codec/format bindings by introspecting real FFmpeg binaries. Each version package (`v5`, `v6`, `v7`, `v8`, `v9`) is generated from the corresponding FFmpeg major version.
 
 ## How It Works
 
@@ -52,8 +52,11 @@ For local code generation you need multiple FFmpeg versions installed side by si
 ### macOS (Homebrew)
 
 ```bash
-brew install ffmpeg@5 ffmpeg@6 ffmpeg@7 ffmpeg      # ffmpeg (no suffix) = latest (v8+)
+brew install ffmpeg@5 ffmpeg@6 ffmpeg@7 ffmpeg      # ffmpeg (no suffix) = latest (v9)
 ```
+
+Homebrew has no `ffmpeg@8` formula, so `packages/v8` cannot be generated locally on
+macOS — use the Docker image or `ci-codegen-versions.yml` for that version.
 
 Then invoke the generator by pointing `PATH` at the desired version:
 
@@ -124,3 +127,4 @@ Use `--rebuild` to bypass the cache and regenerate from scratch.
 | `packages/v6` | 6.1 | `ghcr.io/lucemia/typed-ffmpeg/ffmpeg:6.1` |
 | `packages/v7` | 7.1 | `ghcr.io/lucemia/typed-ffmpeg/ffmpeg:7.1` |
 | `packages/v8` | 8.0 | `ghcr.io/lucemia/typed-ffmpeg/ffmpeg:8.0` |
+| `packages/v9` | 9.0 | `ghcr.io/lucemia/typed-ffmpeg/ffmpeg:9.0` |

--- a/docs/version-differences.md
+++ b/docs/version-differences.md
@@ -87,10 +87,9 @@ command line that contains `-dec` is not, and raises a clear error.
 
 ## FFmpeg 7 → 8
 
-### Filters added (6)
+### Filters added (5)
 
-`colordetect`, `coreimage`, `coreimagesrc`, `premultiply_dynamic`, `scale_vt`,
-`transpose_vt`
+`colordetect`, `coreimage`, `coreimagesrc`, `scale_vt`, `transpose_vt`
 
 ### Filters removed (67)
 
@@ -144,9 +143,41 @@ third-party-library filters were removed from the default build:
 `vc1_cuvid`, `vc1_v4l2m2m`, `vp8_cuvid`, `vp8_v4l2m2m`, `vp8_vaapi`,
 `vp9_cuvid`, `vp9_v4l2m2m`, `vp9_vaapi`
 
-### Formats added (5)
+### Formats added (3)
 
-`apv`, `g728`, `hxvs`, `jpegxs_pipe`, `whip`
+`apv`, `g728`, `whip`
+
+---
+
+## FFmpeg 8 → 9
+
+### Filters added (3)
+
+`premultiply_dynamic`, `transpose_cuda`, `v360_vulkan`
+
+### Codecs added (11)
+
+`adpcm_circus`, `adpcm_ima_escape`, `adpcm_ima_hvqm2`, `adpcm_ima_hvqm4`,
+`adpcm_ima_magix`, `adpcm_ima_pda`, `adpcm_n64`, `adpcm_psxc`, `ahx`,
+`prores_ks_vulkan`, `webp_anim`
+
+### Codecs removed (4)
+
+`sonic`, `v308`, `v408`, `v410`
+
+### Formats added (3)
+
+`hxvs`, `jpegxs_pipe`, `webp_anim`
+
+!!! note "Changes outside the default build"
+    These lists come from the bindings, so they only cover what the
+    `ghcr.io/lucemia/typed-ffmpeg/ffmpeg:9.0` build enables. FFmpeg 9.0 also
+    **removes** the CUDA/NPP filters (`scale_npp`, `scale2ref_npp`,
+    `sharpen_npp`, `transpose_npp`), the OMX encoders (`h264_omx`,
+    `mpeg4_omx`) and the CELT decoder (`libcelt`), and **adds** the D3D12
+    filters (`deinterlace_d3d12`, `mestimate_d3d12`, `scale_d3d12`), `frc_amf`,
+    `drawvg` and `ocio`. None of those are built into the Linux image, so they
+    have no bindings in any `typed-ffmpeg` package.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,6 @@ plugins:
             signature_crossrefs: true
             summary: true
             docstring_section_style: table
-            order: source
             docstring_style: google
             extensions:
               - griffe_inherited_docstrings

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@ Core runtime for typed-ffmpeg multi-version packages.
 
 ## Overview
 
-`ffmpeg-core` contains the hand-written runtime code that is shared across all FFmpeg version bindings (v5, v6, v7, v8). This package is automatically installed as a dependency when you install any `typed-ffmpeg-vX` package.
+`ffmpeg-core` contains the hand-written runtime code that is shared across all FFmpeg version bindings (v5, v6, v7, v8, v9). This package is automatically installed as a dependency when you install any `typed-ffmpeg-vX` package.
 
 ## What's Inside
 
@@ -19,7 +19,7 @@ This package is installed automatically:
 
 ```bash
 # Installing any version package will install ffmpeg-core
-pip install typed-ffmpeg-v8
+pip install typed-ffmpeg-v9
 
 # You can also install it directly (advanced)
 pip install ffmpeg-core

--- a/packages/core/src/ffmpeg_core/common/cache.py
+++ b/packages/core/src/ffmpeg_core/common/cache.py
@@ -39,14 +39,14 @@ def _get_data_cache_path() -> Path | None:
     """
     Get the cache path from an installed ffmpeg-data-vN package.
 
-    Tries ffmpeg_data_v8 through ffmpeg_data_v5 (newest first) and returns
+    Tries ffmpeg_data_v9 through ffmpeg_data_v5 (newest first) and returns
     the first one found. Returns None if no data package is installed.
 
     Returns:
         Path to the data cache directory, or None if not installed.
 
     """
-    for version in ("v8", "v7", "v6", "v5"):
+    for version in ("v9", "v8", "v7", "v6", "v5"):
         try:
             mod = __import__(f"ffmpeg_data_{version}")
             return mod.get_cache_path()

--- a/packages/tests-shared/conftest.py
+++ b/packages/tests-shared/conftest.py
@@ -1,4 +1,4 @@
-"""Conftest for shared tests across typed-ffmpeg v5-v8.
+"""Conftest for shared tests across typed-ffmpeg v5-v9.
 
 Most snapshots are identical across versions, so a single __snapshots__ dir is used.
 Version-sensitive tests (e.g., CLI parsing that depends on options.json data) use

--- a/scripts/add-lazy-import.py
+++ b/scripts/add-lazy-import.py
@@ -93,7 +93,7 @@ def main():
     """Add lazy imports to all streams files."""
     repo_root = Path(__file__).parent.parent
 
-    for version in ["v5", "v6", "v7", "v8"]:
+    for version in ["v5", "v6", "v7", "v8", "v9"]:
         print(f"\n📦 Processing {version}...")
 
         streams_dir = repo_root / "packages" / version / "src" / "ffmpeg" / "streams"

--- a/scripts/create-stubs.py
+++ b/scripts/create-stubs.py
@@ -14,7 +14,6 @@ STUB_MODULES = {
     "expressions.py": "expressions",
     "types.py": "types",
     "schema.py": "schema",
-    "base.py": "base",
     "info.py": "info",
     "common/__init__.py": "common",
     "common/schema.py": "common.schema",
@@ -23,10 +22,15 @@ STUB_MODULES = {
     "utils/frozendict.py": "utils.frozendict",
     "utils/typing.py": "utils.typing",
     "utils/escaping.py": "utils.escaping",
-    "utils/snapshot.py": "utils.snapshot",
-    "utils/view.py": "utils.view",
     "utils/lazy_eval/__init__.py": "utils.lazy_eval",
 }
+
+# Deliberately NOT stubbed: base.py, utils/snapshot.py and utils/view.py.
+# ffmpeg_core has no `base` module, and ffmpeg_core.utils.{snapshot,view} are
+# tombstones that raise ImportError because they depend on the DAG layer. Each
+# version package ships its own real implementation of these three, and
+# create_stub() overwrites unconditionally -- listing them here replaced working
+# code with broken re-export stubs in every version package.
 
 
 def create_stub(file_path: Path, module_name: str):
@@ -44,7 +48,7 @@ def main():
     repo_root = Path(__file__).parent.parent
     packages_dir = repo_root / "packages"
 
-    for version_dir in ["v5", "v6", "v7", "v8"]:
+    for version_dir in ["v5", "v6", "v7", "v8", "v9"]:
         version_path = packages_dir / version_dir / "src" / "ffmpeg"
 
         if not version_path.exists():

--- a/scripts/fix-dag-imports.py
+++ b/scripts/fix-dag-imports.py
@@ -47,7 +47,7 @@ def main():
     repo_root = Path(__file__).parent.parent
     packages_dir = repo_root / "packages"
 
-    for version_dir in ["v5", "v6", "v7", "v8"]:
+    for version_dir in ["v5", "v6", "v7", "v8", "v9"]:
         dag_path = packages_dir / version_dir / "src" / "ffmpeg" / "dag"
 
         if not dag_path.exists():

--- a/scripts/fix-monorepo-imports.py
+++ b/scripts/fix-monorepo-imports.py
@@ -78,7 +78,7 @@ def main():
     packages_dir = repo_root / "packages"
 
     # Process each version package
-    for version_dir in ["v5", "v6", "v7", "v8"]:
+    for version_dir in ["v5", "v6", "v7", "v8", "v9"]:
         version_path = packages_dir / version_dir / "src" / "ffmpeg"
 
         if not version_path.exists():

--- a/src/scripts/parse_docs/cli.py
+++ b/src/scripts/parse_docs/cli.py
@@ -59,14 +59,28 @@ def process_docs() -> list[FilterDocument]:
 
     """
     # split documents into individual files for easier processing
+    # texinfo now emits the section anchors *inside* the heading:
+    #   <h3 class="section">8.5 acrossfade<span class="pull-right">...</span></h3>
+    # rather than wrapping the whole title in a single <a href="#toc-...">. Match
+    # the heading itself and treat everything up to the next heading as the body,
+    # which works for both the old and the current markup.
     section_pattern = re.compile(
-        r'(?P<body><h[34] class="(?:section|subsection)"><a href="(.*?)">(?P<name>.*?)</a></h[34]>(.*?))<span',
+        r'<h(?P<level>[34]) class="(?:section|subsection)">(?P<name>.*?)</h(?P=level)>',
         re.MULTILINE | re.DOTALL,
     )
 
     def extract_filter(html: str) -> list[tuple[str, str]]:
+        matches = list(section_pattern.finditer(html))
         return [
-            (m.group("name"), m.group("body")) for m in section_pattern.finditer(html)
+            (
+                m.group("name"),
+                html[
+                    m.start() : matches[i + 1].start()
+                    if i + 1 < len(matches)
+                    else len(html)
+                ],
+            )
+            for i, m in enumerate(matches)
         ]
 
     infos: list[FilterDocument] = []

--- a/src/scripts/parse_docs/helpers.py
+++ b/src/scripts/parse_docs/helpers.py
@@ -67,21 +67,41 @@ def parse_filter_document(body: str) -> FilterDocument:
 
     assert isinstance(h3, Tag)
 
-    title = h3.text
+    # The heading carries trailing "#" / "TOC" anchor links in a pull-right span.
+    # That is navigation chrome, not part of the filter title, so drop it before
+    # reading the text. Parse a copy so the caller's soup keeps the anchors.
+    heading = BeautifulSoup(str(h3), "html.parser").find(["h3", "h4"])
+    assert isinstance(heading, Tag)
+    for span in heading.find_all("span", class_="pull-right"):
+        span.decompose()
+
+    title = heading.text.strip()
     index, filter_namestr = title.split(" ", 1)
     filter_names = (i.strip() for i in filter_namestr.split(","))
 
-    assert isinstance(h3.a, Tag)
-    assert isinstance(h3.a["href"], str)
+    # Prefer the "#toc-<name>" anchor; older markup put it on the heading's only
+    # <a>, current markup puts it alongside a plain "#<name>" self-link.
+    toc_anchor = h3.find(
+        "a", href=lambda h: isinstance(h, str) and h.startswith("#toc-")
+    )
+    if isinstance(toc_anchor, Tag):
+        href = toc_anchor["href"]
+    else:
+        assert isinstance(h3.a, Tag)
+        href = h3.a["href"]
+    assert isinstance(href, str)
 
-    ref = h3.a["href"].replace("#toc-", "").replace("-1", "")
+    ref = href.replace("#toc-", "").replace("-1", "")
 
     # check cross reference
     refs: set[str] = set()
     a: Tag
     for a in soup.find_all("a"):
         href = a.get("href")
-        assert isinstance(href, str)
+        # Sections contain name-only anchors (<a name="..."></a>) as link
+        # targets; they carry no href and are not cross-references.
+        if not isinstance(href, str):
+            continue
         if href.startswith("#") and not href.startswith("#toc-"):
             refs.add(href[1:])
 

--- a/uv.lock
+++ b/uv.lock
@@ -741,15 +741,6 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
-]
-
-[[package]]
 name = "html2text"
 version = "2025.4.15"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
Finishes the parts of #999 that were still pinned to v5–v8. The v9 scaffold, the 9.0 metadata cache and the generated bindings already landed via #1007, and sections 1–4 and 6 of the issue checklist are done on `main`; this is the remainder.

It also repairs three CI failures that arrived with the 2026-08-20 dependabot merges plus an upstream HTML change. All four predate this branch and fail identically on `main` — no CI workflow had run there since, so they surfaced here first.

## 1. Runtime (user-visible bug)

`ffmpeg_core.common.cache._get_data_cache_path()` iterated `("v8", "v7", "v6", "v5")`. Now that `packages/latest` targets v9, `pip install typed-ffmpeg[parse]` installs `ffmpeg-data-v9` **and nothing else**, so the lookup found no data package and `parse()` raised `FileNotFoundError: Cache file not found: list/options.json`.

This only reproduces on a wheel install — `packages/core`'s `cache/list` is not shipped, but an editable checkout has it locally, which is why the test suite never caught it. Reproduced in a clean venv with only `ffmpeg-core` + `typed-ffmpeg-v9` + `ffmpeg-data-v9`:

| | `_get_data_cache_path()` | `parse()` |
|---|---|---|
| before | `None` | `FileNotFoundError` |
| after | `…/ffmpeg_data_v9/cache` | resolves |

## 2. Scripts

- `create-stubs.py`, `add-lazy-import.py`, `fix-dag-imports.py`, `fix-monorepo-imports.py` skipped `packages/v9`.
- `create-stubs.py` also listed `base.py`, `utils/snapshot.py` and `utils/view.py` as `ffmpeg_core` re-exports. `ffmpeg_core.base` does not exist, and `ffmpeg_core.utils.{snapshot,view}` are DAG tombstones that raise `ImportError` — yet each version package ships its own real implementation (`v8/src/ffmpeg/base.py` is 6.3 KB). Because `create_stub()` writes unconditionally, running the script replaced working code with two-line broken stubs in **every** version package. Adding v9 would have widened that, so the entries are removed and the omission documented.

## 3. CI (`ci-monorepo-lint.yml`)

Ran its circular-import check against `packages/v8`.

## 4. Docs

New **FFmpeg 8 → 9** section in `version-differences.md`, generated with `code_gen.cli diff 8.0 9.0` and then verified entry-by-entry against FFmpeg's `allfilters.c` / `allcodecs.c` / `allformats.c` on `release/8.0` and `release/9.0` — all 21 entries check out.

That verification also turned up an error in the existing **7 → 8** section: `premultiply_dynamic`, `hxvs` and `jpegxs_pipe` are listed as 8.0 additions, but none of them exist in 8.0 source — they are 9.0 additions, misattributed by a macOS-vs-Linux capture mismatch. Corrected here.

> [!NOTE]
> The rest of that 7 → 8 section has the same defect — `coreimage`, `coreimagesrc`, `scale_vt` and `transpose_vt` are all present in 7.1 source and only *appear* new in 8 because the v7 cache is a Linux capture and the v8 one was macOS. Out of scope for #999; worth its own issue.

Also updated: `codegen.md` (v9 matrix row, plus a note that Homebrew has no `ffmpeg@8` formula — plain `ffmpeg` is now 9.0.1 — so v8 requires Docker), `README.md`, `packages/core/README.md`, `CONTRIBUTING.md` (11 → 13 packages), and the `tests-shared/conftest.py` docstring.

---

## CI repairs (pre-existing on `main`)

**`uv.lock` — broke all five `generate` jobs.** #1036 (griffe-inherited-docstrings 1.1.1 → 1.1.3) left two byte-identical `griffelib` 2.2.0 `[[package]]` blocks, so `uv` rejected the whole file with *"Dependency `griffelib` has missing `source` field but has more than one matching package"* and `uv sync` failed. Reproduced on a clean checkout of `main` at 60b06567. Dropping the duplicate leaves `uv lock --check` clean with no resolution changes.

**`mkdocs.yml` — broke `docs`.** #1035 (mkdocstrings-python 1.16.12 → 2.0.6) turned unrecognised handler options into hard errors, so `order: source` aborted the build with *"PythonOptions.__init__() got an unexpected keyword argument 'order'"*. There is no `order` option — the real one is `members_order` — so the key has been silently ignored since #813 and the reference pages have always rendered alphabetically. Removed rather than renamed, to keep a CI fix from also reordering every reference page. If source ordering was the intent, `members_order: source` is the follow-up.

**`fix-encoding-pragma` — broke `Apply generated output`.** #1021 bumped pre-commit-hooks v5 → v6, which deleted that hook. The config still referenced it, so every pre-commit invocation exited 1 regardless of the files checked. It ran with `args: [--remove]`, i.e. only to strip `# -*- coding: utf-8 -*-` headers; no file under `src/` or `packages/` has one and nothing in codegen emits them.

**Filter-doc scraper — broke `test`.** ffmpeg.org regenerated `ffmpeg-filters.html` with a newer texinfo that moved the section anchors inside the heading:

```
before: <h3 class="section"><a href="#toc-acrossfade">8.5 acrossfade</a></h3>
now:    <h3 class="section">8.5 acrossfade<span class="pull-right">
          <a href="#acrossfade">#</a> <a href="#toc-acrossfade">TOC</a></span></h3>
```

The section regex required the leading `<a href>`, so `process_docs()` returned 0 documents and `extract_docs("acrossfade")` raised `Unknown filter acrossfade`. Codegen prefers the version-correct texi docs and swallows the `ValueError`, so the HTML fallback was silently dead rather than visibly broken. The parser now matches the heading itself and takes everything up to the next heading as the body, handling both markups; 926 sections and 600 filter names parse again.

## Verification

- `packages/tests-shared`: 198 passed / 8 skipped against **both** v8 and v9
- `src/scripts`: 141 passed / 40 skipped, all 75 snapshots unchanged
- `prek run --all-files` green; `uv lock --check`, `uv sync` and `mkdocs build` all succeed
- `scripts/create-stubs.py` runs across v5–v9 leaving the tree untouched
- All 22 PR checks green

## Not included

Checklist item 9 (bump all 13 packages, TestPyPI, then PyPI) is a maintainer release step, so #999 is referenced rather than closed.

Separately, `origin/feat/ffmpeg-9-support` is a parallel implementation of this issue, now superseded by #1007 + this PR and 37 commits behind `main`. Left untouched — it can probably be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLyDtvWNYRKzMeuWr3NhPR