### PR TITLE
docs: publish the v5-v9 API reference, which was silently absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,5 +212,8 @@ output.mp4
 /ffmpeg/
 .claude/settings.local.json
 .claude/memory/
-docs/_stubs/
+# docs/_stubs holds the tracked ffmpeg_vN -> packages/vN/src/ffmpeg symlinks
+# that mkdocstrings resolves the per-version API reference through. It must
+# exist before mkdocstrings initialises, so it cannot be generated at build
+# time -- see scripts/gen_ref_pages.py and mkdocs.yml's handler `paths`.
 package-lock.json

--- a/docs/_stubs/ffmpeg_v5
+++ b/docs/_stubs/ffmpeg_v5
@@ -1,0 +1,1 @@
+../../packages/v5/src/ffmpeg

--- a/docs/_stubs/ffmpeg_v6
+++ b/docs/_stubs/ffmpeg_v6
@@ -1,0 +1,1 @@
+../../packages/v6/src/ffmpeg

--- a/docs/_stubs/ffmpeg_v7
+++ b/docs/_stubs/ffmpeg_v7
@@ -1,0 +1,1 @@
+../../packages/v7/src/ffmpeg

--- a/docs/_stubs/ffmpeg_v8
+++ b/docs/_stubs/ffmpeg_v8
@@ -1,0 +1,1 @@
+../../packages/v8/src/ffmpeg

--- a/docs/_stubs/ffmpeg_v9
+++ b/docs/_stubs/ffmpeg_v9
@@ -1,0 +1,1 @@
+../../packages/v9/src/ffmpeg

--- a/packages/tests-shared/test_version_consistency.py
+++ b/packages/tests-shared/test_version_consistency.py
@@ -186,6 +186,32 @@ def test_no_nested_version_tree(major: str) -> None:
 
 
 @pytest.mark.parametrize("major", MAJORS)
+def test_has_reference_docs_stub(major: str) -> None:
+    """
+    Each version package needs its docs/_stubs alias to be documented.
+
+    Every version package installs its bindings as `ffmpeg`, so documenting
+    five of them needs five distinct importable names; mkdocs.yml lists
+    docs/_stubs in the mkdocstrings handler `paths` for that reason, and
+    gen_ref_pages.py skips any version whose alias is missing. The directory
+    used to be gitignored and created by nothing, so every version was skipped
+    and the published docs carried no v5-v9 API reference at all. It cannot be
+    generated during the build either -- mkdocstrings drops `paths` entries
+    that do not exist when it initialises, before gen-files runs.
+    """
+    stub = ROOT / "docs" / "_stubs" / f"ffmpeg_v{major}"
+    assert stub.is_symlink(), (
+        f"docs/_stubs/ffmpeg_v{major} is missing, so v{major} gets no API "
+        f"reference. Create it with:\n"
+        f"  ln -s ../../packages/v{major}/src/ffmpeg docs/_stubs/ffmpeg_v{major}"
+    )
+    expected = ROOT / "packages" / f"v{major}" / "src" / "ffmpeg"
+    assert stub.resolve() == expected.resolve(), (
+        f"docs/_stubs/ffmpeg_v{major} points at {stub.resolve()}, expected {expected}"
+    )
+
+
+@pytest.mark.parametrize("major", MAJORS)
 def test_documented_and_measured(major: str) -> None:
     """Docs and coverage config both enumerate the binding packages."""
     for rel, needle in (


### PR DESCRIPTION
The docs half of the two leftovers noted when #999 was closed. **The ruff half is deliberately not here** — see the end.

## The published docs have never carried the v5–v9 API reference

`mkdocs.yml` lists `docs/_stubs` in the mkdocstrings handler `paths`, and `gen_ref_pages.py` documents each version through an `ffmpeg_vN` alias there. The aliases are necessary: all five version packages install their bindings as `ffmpeg`, so documenting them together needs five distinct importable names.

Nothing ever created that directory, and `.gitignore` ignored it. `gen_ref_pages.py` skips any version whose alias is missing:

```python
stub = stubs_dir / f"ffmpeg_{version}"
if not stub.exists():
    continue
```

So every version was skipped on every build. The site has only ever had the `ffmpeg_core` reference, and the entire per-version loop — including the `VERSIONS` list that #999's checklist asked to keep updated — has been dead code the whole time.

## Why the links are tracked rather than generated

Generating them at build time does not work. mkdocstrings drops `paths` entries that do not exist when it initialises, and that happens before `mkdocs-gen-files` runs its scripts. Creating the symlinks from `gen_ref_pages.py` leaves them out of `sys.path` and the build fails:

```
ERROR - mkdocstrings: With sys.path = [...packages/core/src, ...],
        accessing 'ffmpeg_v5' raises ModuleNotFoundError: No module named 'ffmpeg_v5'
ERROR - Could not collect 'ffmpeg_v5.base'
Aborted with a BuildError!
```

I tried that first; this is why the diff is five tracked symlinks (`mode 120000`) plus the removal of the ignore rule, rather than a few lines of Python.

Because that reintroduces a per-version thing to maintain, `test_version_consistency` gains a guard asserting each discovered major has a stub pointing at the right package. The failure mode here is silent omission, not an error, so it needs a test rather than trust.

## Result

| | before | after |
|---|---|---|
| HTML pages | 24 | 334 |
| reference trees | `ffmpeg_core` | `ffmpeg_core`, `v5`, `v6`, `v7`, `v8`, `v9` |
| docs build | ~23s | ~2m50s |

The build-time increase is real and worth knowing before someone treats the `docs` job duration as a regression: mkdocstrings now collects five complete binding trees. Spot-checked that the output is genuine — `reference/v9/filters/index.html` is 1.3 MB of rendered API documentation.

Verified the symlinks do not create a new lint trap: ruff does not traverse them, so `ruff check .` reports nothing under `docs/_stubs`.

`prek run --all-files` green; `packages/tests-shared` 211 passed / 8 skipped; `src/scripts` unchanged (138 passed, same 5 pre-existing failures for missing local FFmpeg sources).

## The ruff config-roots finding is not fixed here, on purpose

`packages/v8/pyproject.toml` and `packages/v9/pyproject.toml` each declare a three-line `[tool.ruff]`, which makes ruff treat those directories as separate config roots, so the repo-root generated-code `exclude` never reaches them and `ruff check packages/` reports ~7.6k findings in the two of them.

I implemented the obvious fix — delete both blocks — and it works: `ruff check packages/` goes to *All checks passed!* and v8/v9 behave like v5–v7. Then I measured what else it changes, and backed it out. Distance from `ruff format` canonical form, per version:

| | diff lines (filters.py + sources.py + streams/video.py) | meaning |
|---|---|---|
| v5 | 54,288 | raw generator output |
| v7 | 65,190 | raw generator output |
| v8 | 788 | ruff-formatted |
| v9 | 788 | ruff-formatted |

The ruff-format pre-commit hook passes `--force-exclude`, so the root `exclude` suppresses formatting as well as linting. Only v8/v9 ever escaped it — through the very nested configs in question — so only they have ever been formatted. Deleting the blocks makes them excluded too, and the next regeneration would rewrite them as raw output: a one-time ~50k-line churn, "fixing" the inconsistency by making v8/v9 worse rather than v5–v7 better.

Every alternative has a comparable cost. Moving the pattern to `[tool.ruff.lint] exclude` so formatting still applies would reformat v5–v7 instead — the same churn, in the other direction. Adding `[tool.ruff.lint] exclude` to just the two nested configs fixes the `ruff check` trap with no churn at all, but leaves the config-root oddity in place.

That is a decision about what the canonical committed form of generated code should be, and it wants an owner rather than a drive-by. Happy to implement whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NekroFCFe6NuJCzAEivaKt
