### PR TITLE
ci: deploy docs on push to main instead of a tag filter that never matched

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,10 +1,22 @@
 name: Deploy Documentation
 
 on:
+  # Was `tags: ['[0-9]*']`, which requires a tag starting with a digit. This
+  # project tags releases as v4.5, so nothing ever matched: the last automatic
+  # deploy was 2026-03-26 and v4.1 through v4.5 all shipped without a docs
+  # update. Tracking main keeps the site current by construction, rather than
+  # depending on a filter that matches the tag convention.
   push:
-    tags:
-      - '[0-9]*'
+    branches: [main]
   workflow_dispatch:
+
+# ghp-import force-pushes gh-pages, so two overlapping runs race and the one
+# that finishes last wins -- which need not be the newer commit. Superseded
+# runs are cancelled instead; nothing is published until the final push, so
+# cancelling mid-build leaves the site untouched.
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,7 +383,7 @@ The script will:
 5. Create a GitHub Release via `gh` CLI (triggers `monorepo-publish.yml`)
 
 The publish workflow builds all packages and publishes to PyPI in dependency order:
-core → data → bindings → meta. Documentation is deployed automatically via `deploy-docs.yml` on version tags.
+core → data → bindings → meta. Documentation is deployed automatically via `deploy-docs.yml` on every push to `main`.
 
 #### Manual / Partial Publish
 


### PR DESCRIPTION
Follow-up to #1042, which fixed the docs *content* but left them undeployed.

## The trigger has never matched

```yaml
on:
  push:
    tags:
      - '[0-9]*'      # requires a tag starting with a digit
```

Releases here are tagged `v4.5`, `v4.4`, … — none of them start with a digit, so the filter has never fired. Run history:

| date | event | ref |
|---|---|---|
| 2026-04-08 | `workflow_dispatch` | `v4.0.1` |
| 2026-03-26 | `push` | `main` |
| 2026-03-26 | `push` | `main` |

The last automatic deploy was **2026-03-26**, back when the trigger still included `main`. Everything since — `v4.1` through `v4.5`, including the release published today — shipped without a docs update. The live site was five months behind `main` and 404'd on the entire `/reference/` tree until I dispatched the workflow by hand after merging #1042.

## The change

Trigger on `push: branches: [main]`, keeping `workflow_dispatch`. Per your call — it keeps the site current by construction, rather than depending on a filter that agrees with the tag convention. The tag trigger is removed rather than corrected to `v[0-9]*`, since deploying on both would double-build every release.

The cost is a docs build on every merge to `main`: roughly **six minutes**, now that the v5–v9 reference actually renders. That is the trade-off you're accepting over deploying only on release.

**Also added a concurrency group.** This matters specifically because the trigger is now `main`: the deploy step is `ghp-import -n -p -f site`, a force-push to `gh-pages`, so two overlapping runs race and whichever finishes last wins — which need not be the newer commit. Two merges in quick succession could leave the site on the older one. Superseded runs are now cancelled, which is safe because nothing is published until that final push, so cancelling mid-build leaves the site untouched.

## Docs correction

`CONTRIBUTING.md` said documentation "is deployed automatically via `deploy-docs.yml` on version tags". That was wrong twice over — not what the workflow said (`[0-9]*`, not `v[0-9]*`), and not what it did (nothing). Now says on every push to `main`.

## Verification

YAML parses; `prek run --all-files` green. The trigger itself can only really be verified by merging — the first push to `main` after this lands should produce a `deploy-docs` run, which is worth watching once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NekroFCFe6NuJCzAEivaKt
